### PR TITLE
Code review and cleanup

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -19,4 +19,4 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+        run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs = ["", "docs"])'

--- a/Project.toml
+++ b/Project.toml
@@ -6,9 +6,14 @@ version = "2.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1.3"
 LinearMaps = "3.3"
+
+[extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Random", "Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.24, 0.25, 0.26, 0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,5 +27,6 @@ makedocs(
 
 deploydocs(
   repo = "github.com/andreasvarga/MatrixEquations.jl.git",
+  push_preview = true,
   target = "build",
   )

--- a/src/MatrixEquations.jl
+++ b/src/MatrixEquations.jl
@@ -20,7 +20,7 @@ export lanv2, ladiv, lag2, lacn2!
 export lyapc, lyapd, lyapcs!, lyapds! 
 export plyapc, plyaps, plyapcs!, plyapd, plyapds!  
 export arec, ared, garec, gared
-export sylvc, sylvd, gsylv, sylvcs!, sylvds!, gsylvs!, gsylvs1!
+export sylvc, sylvd, gsylv, sylvcs!, sylvds!, gsylvs!
 export sylvsys, dsylvsys, sylvsyss!, dsylvsyss!, tgsyl!
 export sylvckr, sylvdkr, gsylvkr, sylvsyskr, dsylvsyskr
 export opnorm1, opnorm1est, oprcondest, opsepest

--- a/src/MatrixEquations.jl
+++ b/src/MatrixEquations.jl
@@ -6,8 +6,9 @@ const BlasReal = Union{Float64,Float32}
 const BlasComplex = Union{ComplexF64,ComplexF32}
 
 using LinearAlgebra
+using LinearAlgebra: require_one_based_indexing
+import LinearAlgebra: mul!
 using LinearMaps
-import LinearAlgebra: require_one_based_indexing
 
 
 include("lapackutil.jl")

--- a/src/condest.jl
+++ b/src/condest.jl
@@ -25,11 +25,11 @@ julia> opnorm1(invlyapop(A))
 ```
 """
 function opnorm1(op::LinearMaps.LinearMap{T}) where T
-  (m, n) = size(op)
-  Tnorm = real(T)
-  Tsum = promote_type(Float64, Tnorm)
-  nrm::Tsum = 0
-  for j = 1 : n
+   (m, n) = size(op)
+   Tnorm = real(T)
+   Tsum = promote_type(Float64, Tnorm)
+   nrm::Tsum = 0
+   for j = 1 : n
       ej = zeros(Tsum, n)
       ej[j] = 1
       try
@@ -40,9 +40,10 @@ function opnorm1(op::LinearMaps.LinearMap{T}) where T
          findfirst("SingularException",string(err)) === nothing &&
          findfirst("LAPACKException",string(err)) === nothing ? rethrow() : (return Inf)
       end
-  end
-  return convert(Tnorm, nrm)
+   end
+   return convert(Tnorm, nrm)
 end
+
 """
     γ = opnorm1est(op)
 
@@ -66,42 +67,42 @@ julia> opnorm1est(invlyapop(A))
 3.76666666666667
 ```
 """
-function opnorm1est(op::LinearMaps.LinearMap) 
-  m, n = size(op)
-  m == n || throw(DimensionMismatch("The operator op must be square"))
-  T = promote_type(Float64,eltype(op))
-  TR = real(T)
-  TR == Float64 ? SMLNUM = reinterpret(Float64, 0x2000000000000000) : SMLNUM = reinterpret(Float32, 0x20000000)
-  BIGNUM = 2*eps(TR) / SMLNUM
-  cmplx = T<:Complex
-  V = Array{T,1}(undef,n)
-  X = Array{T,1}(undef,n)
-  cmplx ? ISGN = Array{Int,1}(undef,1) : ISGN = Array{Int,1}(undef,n)
-  ISAVE = Array{Int,1}(undef,3)
-  ANORM = zero(TR)
-  KASE = 0
-  finish = false
-  while !finish
-     if cmplx
-        ANORM, KASE = LapackUtil.lacn2!(V, X, ANORM, KASE, ISAVE )
-     else
-        ANORM, KASE = LapackUtil.lacn2!(V, X, ISGN, ANORM, KASE, ISAVE )
-     end
-     (isfinite(ANORM) && ANORM < BIGNUM) || (return Inf)
-     if KASE != 0
-        try
-           KASE == 1 ? X = op*X : X = op'*X
-        catch err
+function opnorm1est(op::LinearMaps.LinearMap)
+   m, n = size(op)
+   m == n || throw(DimensionMismatch("The operator op must be square"))
+   T = promote_type(Float64,eltype(op))
+   TR = real(T)
+   TR == Float64 ? SMLNUM = reinterpret(Float64, 0x2000000000000000) : SMLNUM = reinterpret(Float32, 0x20000000)
+   BIGNUM = 2*eps(TR) / SMLNUM
+   cmplx = T<:Complex
+   V = Array{T,1}(undef,n)
+   X = Array{T,1}(undef,n)
+   cmplx ? ISGN = Array{Int,1}(undef,1) : ISGN = Array{Int,1}(undef,n)
+   ISAVE = Array{Int,1}(undef,3)
+   ANORM = zero(TR)
+   KASE = 0
+   finish = false
+   while !finish
+      if cmplx
+         ANORM, KASE = LapackUtil.lacn2!(V, X, ANORM, KASE, ISAVE )
+      else
+         ANORM, KASE = LapackUtil.lacn2!(V, X, ISGN, ANORM, KASE, ISAVE )
+      end
+      (isfinite(ANORM) && ANORM < BIGNUM) || (return Inf)
+      if KASE != 0
+         try
+            KASE == 1 ? X = op*X : X = op'*X
+         catch err
          #   if isnothing(findfirst("SingularException",string(err))) &&
          #      isnothing(findfirst("LAPACKException",string(err)))
-           findfirst("SingularException",string(err)) === nothing &&
-           findfirst("LAPACKException",string(err)) === nothing ? rethrow() : (return Inf)
-        end
+            findfirst("SingularException",string(err)) === nothing &&
+            findfirst("LAPACKException",string(err)) === nothing ? rethrow() : (return Inf)
+         end
       else
-        finish = true
-     end
-  end
-  return ANORM
+         finish = true
+      end
+   end
+   return ANORM
 end
 
 """
@@ -116,7 +117,7 @@ The `exact = true` option is not recommended for large order operators.
 The separation of the operator `op` is defined as
 ```math
 \\text{sep} = \\displaystyle\\min_{X\\neq 0} \\frac{\\|op*X\\|}{\\|X\\|}.
-```      
+```
 
 An estimate of the reciprocal condition number of `op` can be computed as ``\\text{sep}/\\|op\\|_1``.
 
@@ -174,15 +175,15 @@ julia> A = [-6. -2. 1.; 5. 1. -1; -4. -2. -1.]
 
 julia> oprcondest(lyapop(A),invlyapop(A))
 0.014749262536873142
- 
+
 julia> 1/opnorm1est(lyapop(A))/opnorm1est(invlyapop(A))
 0.014749262536873142
- 
+
 julia> oprcondest(lyapop(A),invlyapop(A),exact = true)
 0.008849557522123885
- 
+
 julia> 1/opnorm1(lyapop(A))/opnorm1(invlyapop(A))
-0.008849557522123885 
+0.008849557522123885
 ```
 """
 function oprcondest(op::LinearMaps.LinearMap, opinv::LinearMaps.LinearMap; exact = false)
@@ -192,12 +193,12 @@ end
     rcond = oprcondest(op; exact = false)
 
 Compute `rcond`, an estimation of the `1`-norm reciprocal condition number
-of a linear operator `op`, where `op` is one of the defined Lyapunov or Sylvester operators. 
+of a linear operator `op`, where `op` is one of the defined Lyapunov or Sylvester operators.
 The estimate is computed as
 ``\\text{rcond} = 1 / (\\|op\\|_1\\|inv(op)\\|_1)``, using estimates of the `1`-norm, if `exact = false`, or
 computed exact values of the `1`-norm, if `exact = true`.
 The `exact = true` option is not recommended for large order operators.
 """
 function oprcondest(op::MatrixEquationsMaps{T}; kwargs...) where T
-    oprcondest(op, inv(op); kwargs...)
+   oprcondest(op, inv(op); kwargs...)
 end

--- a/src/lapackutil.jl
+++ b/src/lapackutil.jl
@@ -170,7 +170,7 @@ If `WI = 0`, `WR1/SCALE1` and `WR2/SCALE2` are the resulting real eigenvalues, w
 if `WI <> 0`, then `(WR1+/-im*WI)/SCALE1` are the resulting complex eigenvalues.
 Interface to the LAPACK subroutines DLAG2/SLAG2.
 """
-lag2(A::StridedMatrix{BlasReal}, B::StridedMatrix{BlasReal}, SAFMIN::BlasReal) 
+lag2(A::StridedMatrix{BlasReal}, B::StridedMatrix{BlasReal}, SAFMIN::BlasReal)
 
 # lag2(A::StridedMatrix{T}, B::StridedMatrix{T}) where T <: BlasReal = lag2(A,B,safemin(T))
 

--- a/src/lyapunov.jl
+++ b/src/lyapunov.jl
@@ -6,7 +6,7 @@ Compute `X`, the solution of the continuous Lyapunov equation
 
       AX + XA' + C = 0,
 
-where `A` is a square real or complex matrix and `C` is a square matrix. 
+where `A` is a square real or complex matrix and `C` is a square matrix.
 `A` must not have two eigenvalues `α` and `β` such that `α+β = 0`.
 The solution `X` is symmetric or hermitian if `C` is a symmetric or hermitian.
 
@@ -62,7 +62,7 @@ function lyapc(A::AbstractMatrix, C::AbstractMatrix)
    T2 <: BlasFloat  || (T2 = promote_type(Float64,T2))
    eltype(A) == T2 || (adj ? A = convert(Matrix{T2},A.parent)' : A = convert(Matrix{T2},A))
    eltype(C) == T2 || (C = convert(Matrix{T2},C))
- 
+
    # Reduce A to Schur form and transform C
    if adj
       AS, Q = schur(A.parent)
@@ -71,8 +71,8 @@ function lyapc(A::AbstractMatrix, C::AbstractMatrix)
    end
 
    #X = Q'*C*Q
-   if her 
-      X = utqu(C,Q) 
+   if her
+      X = utqu(C,Q)
       lyapcs!(AS, X, adj = adj)
       #X <- Q*X*Q'
       utqu!(X,Q')
@@ -95,9 +95,9 @@ Compute `X`, the solution of the generalized continuous Lyapunov equation
 
      AXE' + EXA' + C = 0,
 
-where `A` and `E` are square real or complex matrices and `C` is a square matrix. 
+where `A` and `E` are square real or complex matrices and `C` is a square matrix.
 The pencil `A-λE` must not have two eigenvalues `α` and `β` such that `α+β = 0`.
-The solution `X` is symmetric or hermitian if `C` is a symmetric or hermitian. 
+The solution `X` is symmetric or hermitian if `C` is a symmetric or hermitian.
 
 The following particular cases are also adressed:
 
@@ -191,8 +191,8 @@ function lyapc(A::AbstractMatrix, E::AbstractMatrix, C::AbstractMatrix)
       x = utqu(C,q)
       lyapcs!(as,es,x, adj = adj)
       #x = z*x*z'
-      utqu!(x,z')  
-      return x 
+      utqu!(x,z')
+      return x
    else
       x = q' * C * q
       adj ? (gsylvs!(as,es,es,as,x,adjAC = true,DBSchur = true)) : (gsylvs!(as,es,es,as,x,adjBD = true,DBSchur = true))
@@ -218,7 +218,7 @@ Compute `X`, the solution of the discrete Lyapunov equation
 
        AXA' - X + C = 0,
 
-where `A` is a square real or complex matrix and `C` is a square matrix. 
+where `A` is a square real or complex matrix and `C` is a square matrix.
 `A` must not have two eigenvalues `α` and `β` such that `αβ = 1`.
 The solution `X` is symmetric or hermitian if `C` is a symmetric or hermitian.
 
@@ -283,7 +283,7 @@ function lyapd(A::AbstractMatrix, C::AbstractMatrix)
       AS, Q = schur(A)
    end
    #X = Q'*C*Q
-   if her 
+   if her
       X = utqu(C,Q)
       lyapds!(AS, X, adj = adj)
       #X <- Q*X*Q'
@@ -291,7 +291,7 @@ function lyapd(A::AbstractMatrix, C::AbstractMatrix)
       return X
    else
       #X = rmul!( Q' * C * Q, -1)
-      X = Q' * C * Q     
+      X = Q' * C * Q
       adj ? (sylvds!(-AS, AS, X, adjA = true)) : (sylvds!(-AS, AS, X, adjB = true))
       return Q * X * Q'
    end
@@ -310,7 +310,7 @@ Compute `X`, the solution of the generalized discrete Lyapunov equation
 
 where `A` and `E` are square real or complex matrices and `C` is a square matrix.
 The pencil `A-λE` must not have two eigenvalues `α` and `β` such that `αβ = 1`.
-The solution `X` is symmetric or hermitian if `C` is a symmetric or hermitian. 
+The solution `X` is symmetric or hermitian if `C` is a symmetric or hermitian.
 
 The following particular cases are also adressed:
 
@@ -351,7 +351,7 @@ julia> X = lyapd(A, E, C)
 2×2 Array{Float64,2}:
   1.775  -1.225
  -1.225   0.775
- 
+
 julia> A*X*A' - E*X*E' + C
 2×2 Array{Float64,2}:
  -2.22045e-16  -4.44089e-16
@@ -372,7 +372,7 @@ function lyapd(A::AbstractMatrix, E::AbstractMatrix, C::AbstractMatrix)
       throw(DimensionMismatch("C must be a square matrix of dimension $n"))
    isequal(E,I) && size(E,1) == n && (return lyapd(A, C))
    LinearAlgebra.checksquare(E) == n || throw(DimensionMismatch("E must be a square matrix of dimension $n"))
- 
+
    adjA = isa(A,Adjoint)
    adjE = isa(E,Adjoint)
    if adjA && !adjE
@@ -404,8 +404,8 @@ function lyapd(A::AbstractMatrix, E::AbstractMatrix, C::AbstractMatrix)
       x = utqu(C,q)
       lyapds!(as,es,x, adj = adj)
       #x = z*x*z'
-      utqu!(x,z')  
-      return x 
+      utqu!(x,z')
+      return x
    else
       x = q' * C * q
       gsylvs!(as, as, -es, es, x, adjAC = adj, adjBD = !adj)
@@ -476,10 +476,10 @@ function lyapcs!(A::Matrix{T1},C::Matrix{T1}; adj = false) where {T1<:BlasReal}
                  # y += A[ia,k]'*C[ia,l]
                  mul!(y,transpose(view(A,ia,k)),view(C,ia,l),ONE,ONE)
                end
-               if i == j 
+               if i == j
                   lyapc2!(adj,y,dk,view(A,k,k),Xw,Yw)
                else
-                  lyapcsylv2!(adj,y,dk,dl,view(A,k,k),view(A,l,l),Xw,Yw)  
+                  lyapcsylv2!(adj,y,dk,dl,view(A,k,k),view(A,l,l),Xw,Yw)
                   transpose!(view(C,l,k),y)
                end
                i += dk
@@ -526,7 +526,7 @@ function lyapcs!(A::Matrix{T1},C::Matrix{T1}; adj = false) where {T1<:BlasReal}
               if i == j
                  lyapc2!(adj,y,dk,view(A,k,k),Xw,Yw)
               else
-                 lyapcsylv2!(adj,y,dk,dl,view(A,k,k),view(A,l,l),Xw,Yw)  
+                 lyapcsylv2!(adj,y,dk,dl,view(A,k,k),view(A,l,l),Xw,Yw)
                  transpose!(view(C,l,k),y)
               end
               i -= dk
@@ -549,7 +549,7 @@ function lyapc2!(adj,C::AbstractMatrix{T},na::Int,A::AbstractMatrix{T},Xw::Abstr
 # speed and reduced allocation oriented implementation of a solver for 1x1 or 2x2 continuous Lyapunov equations
 #      A'*X + X*A = -C if adj = true  -> R = kron(I,A')+kron(A',I) = (kron(I,A)+kron(A,I))'
 #      A*X + X*A' = -C if adj = false -> R = kron(I,A)+kron(A,I)
-   if na == 1 
+   if na == 1
       rmul!(C,inv(-2*A[1,1]))
       any(!isfinite, C) && throw("ME:SingularException: A has eigenvalue(s) ≈ 0")
       return C
@@ -564,10 +564,10 @@ function lyapc2!(adj,C::AbstractMatrix{T},na::Int,A::AbstractMatrix{T},Xw::Abstr
    if adj
       # @inbounds R = [ A[1,1]    A[2,1]         0;
       #                 A[1,2]    A[1,1]+A[2,2]  A[2,1];
-      #                 0         A[1,2]         A[2,2] ] 
+      #                 0         A[1,2]         A[2,2] ]
       @inbounds  R[1,1] = A[1,1]
       @inbounds  R[1,2] = A[2,1]
-      @inbounds  R[1,3] = ZERO 
+      @inbounds  R[1,3] = ZERO
       @inbounds  R[2,1] = A[1,2]
       @inbounds  R[2,2] = A[1,1]+A[2,2]
       @inbounds  R[2,3] = A[2,1]
@@ -577,10 +577,10 @@ function lyapc2!(adj,C::AbstractMatrix{T},na::Int,A::AbstractMatrix{T},Xw::Abstr
    else
       # @inbounds R = [ A[1,1]    A[1,2]         0;
       #                 A[2,1]    A[1,1]+A[2,2]  A[1,2];
-      #                 0         A[2,1]         A[2,2] ] 
+      #                 0         A[2,1]         A[2,2] ]
       @inbounds  R[1,1] = A[1,1]
       @inbounds  R[1,2] = A[1,2]
-      @inbounds  R[1,3] = ZERO 
+      @inbounds  R[1,3] = ZERO
       @inbounds  R[2,1] = A[2,1]
       @inbounds  R[2,2] = A[1,1]+A[2,2]
       @inbounds  R[2,3] = A[1,2]
@@ -596,8 +596,8 @@ function lyapc2!(adj,C::AbstractMatrix{T},na::Int,A::AbstractMatrix{T},Xw::Abstr
    return C
 end
 function lyapcsylv2!(adj,C::AbstractMatrix{T},na::Int,nb::Int,A::AbstractMatrix{T},B::AbstractMatrix{T},Xw::AbstractMatrix{T},Yw::StridedVector{T}) where T <:BlasReal
-# speed and reduced allocation oriented implementation of a solver for 1x1 and 2x2 Sylvester equations 
-# encountered in solving continuous Lyapunov equations: 
+# speed and reduced allocation oriented implementation of a solver for 1x1 and 2x2 Sylvester equations
+# encountered in solving continuous Lyapunov equations:
 #      A'*X + X*B = -C if adj = true  -> R = kron(I,A')+kron(B',I) = (kron(I,A)+kron(B,I))'
 #      A*X + X*B' = -C if adj = false -> R = kron(I,A)+kron(B,I)
    if na == 1 && nb == 1
@@ -856,11 +856,11 @@ function lyapcs!(A::Matrix{T1},E::Union{Matrix{T1},UniformScaling{Bool}}, C::Mat
                  mul!(y,transpose(view(C,ic,k)),view(E,ic,l),ONE,ONE)
                  mul!(y,transpose(view(W,ic,dkk)),view(A,ic,l),ONE,ONE)
              end
-             if i == j 
-                lyapc2!(adj,y,dk,view(A,k,k),view(E,k,k),Xw,Yw)  
+             if i == j
+                lyapc2!(adj,y,dk,view(A,k,k),view(E,k,k),Xw,Yw)
                 copyto!(Ckl,y)
                else
-                lyapcsylv2!(adj,y,dk,dl,view(A,k,k),view(E,k,k),view(A,l,l),view(E,l,l),Xw,Yw)  
+                lyapcsylv2!(adj,y,dk,dl,view(A,k,k),view(E,k,k),view(A,l,l),view(E,l,l),Xw,Yw)
                 copyto!(Ckl,y)
              end
              j += dl
@@ -927,11 +927,11 @@ function lyapcs!(A::Matrix{T1},E::Union{Matrix{T1},UniformScaling{Bool}}, C::Mat
                mul!(y,transpose(view(C,ic,l)),transpose(view(E,k,ic)),ONE,ONE)
                mul!(y,transpose(view(W,ic,dll)),transpose(view(A,k,ic)),ONE,ONE)
             end
-            if i == j 
-               lyapc2!(adj,y,dk,view(A,k,k),view(E,k,k),Xw,Yw)   
+            if i == j
+               lyapc2!(adj,y,dk,view(A,k,k),view(E,k,k),Xw,Yw)
                copyto!(Clk,y)
             else
-               lyapcsylv2!(adj,y,dl,dk,view(A,l,l),view(E,l,l),view(A,k,k),view(E,k,k),Xw,Yw)  
+               lyapcsylv2!(adj,y,dl,dk,view(A,l,l),view(E,l,l),view(A,k,k),view(E,k,k),Xw,Yw)
                copyto!(Clk,y)
             end
             i -= dk
@@ -958,7 +958,7 @@ end
 # LAPACK generated diagonal structure of E is exploited when possible
 #      A'*X*E + E'*X*A = -C if adj = true  -> R = kron(E',A')+kron(A',E') = (kron(E,A)+kron(A,E))'
 #      A*X*E' + E*X*A' = -C if adj = false -> R = kron(E,A)+kron(A,E)
-   if na == 1 
+   if na == 1
       temp = E[1,1]*A[1,1]
       rmul!(C,inv(-2*temp))
       any(!isfinite, C) &&  throw("ME:SingularException: A-λE has zero or infinite eigenvalue(s)")
@@ -972,20 +972,20 @@ end
    @inbounds  Y[2] = -C[2,1]
    @inbounds  Y[3] = -C[2,2]/2
    if adj
-      # Rt =  
+      # Rt =
       #  [        a11*e11,                   a21*e11,         0
       #  a11*e12 + a12*e11, a11*e22 + a21*e12 + a22*e11,   a21*e22
       #          a12*e12,       a12*e22 + a22*e12, a22*e22]
-      # iszero(E[1,2]) ? 
+      # iszero(E[1,2]) ?
       #    (@inbounds R = [  A[1,1]*E[1,1]             A[2,1]*E[1,1]               0 ;
       #                      A[1,2]*E[1,1]    A[1,1]*E[2,2]+A[2,2]*E[1,1]    A[2,1]*E[2,2];
-      #                           0                   A[1,2]*E[2,2]          A[2,2]*E[2,2]]) : 
+      #                           0                   A[1,2]*E[2,2]          A[2,2]*E[2,2]]) :
       #    (@inbounds R = [  A[1,1]*E[1,1]                    A[2,1]*E[1,1]                              0 ;
       #          A[1,1]*E[1,2]+A[1,2]*E[1,1]    A[1,1]*E[2,2]+A[2,1]*E[1,2]+A[2,2]*E[1,1]    A[2,1]*E[2,2];
-      #          A[1,2]*E[1,2]                    A[1,2]*E[2,2]+A[2,2]*E[1,2]                A[2,2]*E[2,2]] ) 
-      @inbounds  R[1,1] = A[1,1]*E[1,1] 
+      #          A[1,2]*E[1,2]                    A[1,2]*E[2,2]+A[2,2]*E[1,2]                A[2,2]*E[2,2]] )
+      @inbounds  R[1,1] = A[1,1]*E[1,1]
       @inbounds  R[1,2] = A[2,1]*E[1,1]
-      @inbounds  R[1,3] = ZERO 
+      @inbounds  R[1,3] = ZERO
       @inbounds  R[2,1] = A[1,1]*E[1,2]+A[1,2]*E[1,1]
       @inbounds  R[2,2] = A[1,1]*E[2,2]+A[2,1]*E[1,2]+A[2,2]*E[1,1]
       @inbounds  R[2,3] = A[2,1]*E[2,2]
@@ -993,18 +993,18 @@ end
       @inbounds  R[3,2] = A[1,2]*E[2,2]+A[2,2]*E[1,2]
       @inbounds  R[3,3] = A[2,2]*E[2,2]
    else
-      # R =  
+      # R =
       # [ a11*e11,       a11*e12 + a12*e11,         a12*e12
       # a21*e11, a11*e22 + a21*e12 + a22*e11, a12*e22 + a22*e12
       #       0,                   a21*e22,         a22*e22]
-      # iszero(E[1,2]) ? 
+      # iszero(E[1,2]) ?
       #    (@inbounds  R = [  A[1,1]*E[1,1]            A[1,2]*E[1,1]                    0;
       #                       A[2,1]*E[1,1]    A[1,1]*E[2,2]+A[2,2]*E[1,1]     A[1,2]*E[2,2];
       #                             0                  A[2,1]*E[2,2]           A[2,2]*E[2,2]] ) :
       #    (@inbounds  R = [  A[1,1]*E[1,1]    A[1,1]*E[1,2]+A[1,2]*E[1,1]             A[1,2]*E[1,2];
       #           A[2,1]*E[1,1]    A[1,1]*E[2,2]+A[2,1]*E[1,2]+A[2,2]*E[1,1]     A[1,2]*E[2,2]+A[2,2]*E[1,2];
       #                 0                   A[2,1]*E[2,2]                              A[2,2]*E[2,2]] )
-      @inbounds  R[1,1] = A[1,1]*E[1,1] 
+      @inbounds  R[1,1] = A[1,1]*E[1,1]
       @inbounds  R[1,2] = A[1,1]*E[1,2]+A[1,2]*E[1,1]
       @inbounds  R[1,3] = A[1,2]*E[1,2]
       @inbounds  R[2,1] = A[2,1]*E[1,1]
@@ -1022,7 +1022,7 @@ end
    return C
 end
 @inline function lyapcsylv2!(adj,C::AbstractMatrix{T},na::Int,nb::Int,A::AbstractMatrix{T},E::AbstractMatrix{T},B::AbstractMatrix{T},F::AbstractMatrix{T},Xw::AbstractMatrix{T},Yw::StridedVector{T}) where T <:BlasReal
-# speed and reduced allocation oriented implementation of a solver for 1x1 and 2x2 Sylvester equations 
+# speed and reduced allocation oriented implementation of a solver for 1x1 and 2x2 Sylvester equations
 # encountered in solving generalized continuous Lyapunov equations:
 #      A'*X*F + E'*X*B = -C if adj = true  -> R = kron(F',A')+kron(B',E') = (kron(F,A)+kron(B,E))'
 #      A*X*F' + E*X*B' = -C if adj = false -> R = kron(F,A)+kron(B,E)
@@ -1051,9 +1051,9 @@ end
          @inbounds  Y[2] = -C[1,2]
       else
          if nb == 1
-            # R21t = 
+            # R21t =
             # [ a11*f11+b11*e11           a21*f11]
-            # [ a12*f11+b11*e12 a22*f11+b11*e22]                
+            # [ a12*f11+b11*e12 a22*f11+b11*e22]
             # @inbounds R = [ A[1,1]*F[1,1]+B[1,1]*E[1,1]           A[2,1]*F[1,1];
             #                 A[1,2]*F[1,1]+B[1,1]*E[1,2] A[2,2]*F[1,1]+B[1,1]*E[2,2] ]
             @inbounds  R[1,1] = A[1,1]*F[1,1]+B[1,1]*E[1,1]
@@ -1063,16 +1063,16 @@ end
             @inbounds  Y[1] = -C[1,1]
             @inbounds  Y[2] = -C[2,1]
          else
-            # Rt = 
+            # Rt =
             # [ a11*f11+b11*e11           a21*f11           b21*e11                 0]
             # [ a12*f11+b11*e12 a22*f11+b11*e22           b21*e12           b21*e22]
             # [ a11*f12+b12*e11           a21*f12 a11*f22+b22*e11           a21*f22]
             # [ a12*f12+b12*e12 a22*f12+b12*e22 a12*f22+b22*e12 a22*f22+b22*e22]
-            # (iszero(E[1,2]) && iszero(F[1,2])) ? 
+            # (iszero(E[1,2]) && iszero(F[1,2])) ?
             #  (@inbounds R = [ A[1,1]*F[1,1]+B[1,1]*E[1,1]           A[2,1]*F[1,1]           B[2,1]*E[1,1]                 0;
             #                A[1,2]*F[1,1]  A[2,2]*F[1,1]+B[1,1]*E[2,2]           0           B[2,1]*E[2,2];
             #                B[1,2]*E[1,1]        0  A[1,1]*F[2,2]+B[2,2]*E[1,1]           A[2,1]*F[2,2];
-            #                0  B[1,2]*E[2,2] A[1,2]*F[2,2]+B[2,2]*E[1,2] A[2,2]*F[2,2]+B[2,2]*E[2,2]]) : 
+            #                0  B[1,2]*E[2,2] A[1,2]*F[2,2]+B[2,2]*E[1,2] A[2,2]*F[2,2]+B[2,2]*E[2,2]]) :
             #  (@inbounds R = [ A[1,1]*F[1,1]+B[1,1]*E[1,1]           A[2,1]*F[1,1]           B[2,1]*E[1,1]                 0;
             #                A[1,2]*F[1,1]+B[1,1]*E[1,2] A[2,2]*F[1,1]+B[1,1]*E[2,2]           B[2,1]*E[1,2]           B[2,1]*E[2,2];
             #                A[1,1]*F[1,2]+B[1,2]*E[1,1]           A[2,1]*F[1,2] A[1,1]*F[2,2]+B[2,2]*E[1,1]           A[2,1]*F[2,2];
@@ -1082,12 +1082,12 @@ end
             @inbounds  R[1,3] = B[2,1]*E[1,1]
             @inbounds  R[1,4] = ZERO
             @inbounds  R[2,1] = A[1,2]*F[1,1]+B[1,1]*E[1,2]
-            @inbounds  R[2,2] = A[2,2]*F[1,1]+B[1,1]*E[2,2] 
+            @inbounds  R[2,2] = A[2,2]*F[1,1]+B[1,1]*E[2,2]
             @inbounds  R[2,3] = B[2,1]*E[1,2]
             @inbounds  R[2,4] = B[2,1]*E[2,2]
             @inbounds  R[3,1] = A[1,1]*F[1,2]+B[1,2]*E[1,1]
             @inbounds  R[3,2] = A[2,1]*F[1,2]
-            @inbounds  R[3,3] = A[1,1]*F[2,2]+B[2,2]*E[1,1] 
+            @inbounds  R[3,3] = A[1,1]*F[2,2]+B[2,2]*E[1,1]
             @inbounds  R[3,4] = A[2,1]*F[2,2]
             @inbounds  R[4,1] = A[1,2]*F[1,2]+B[1,2]*E[1,2]
             @inbounds  R[4,2] = A[2,2]*F[1,2]+B[1,2]*E[2,2]
@@ -1101,7 +1101,7 @@ end
       end
    else
       if na == 1
-         # R12 = 
+         # R12 =
          # [ a11*f11+b11*e11 a11*f12+b12*e11]
          # [           b21*e11 a11*f22+b22*e11]
          # @inbounds R = [ A[1,1]*F[1,1]+B[1,1]*E[1,1] A[1,1]*F[1,2]+B[1,2]*E[1,1];
@@ -1114,7 +1114,7 @@ end
          @inbounds  Y[2] = -C[1,2]
       else
          if nb == 1
-            # R21 = 
+            # R21 =
             # [ a11*f11+b11*e11 a12*f11+b11*e12]
             # [           a21*f11 a22*f11+b11*e22]
             # @inbounds R = [ A[1,1]*F[1,1]+B[1,1]*E[1,1] A[1,2]*F[1,1]+B[1,1]*E[1,2];
@@ -1126,16 +1126,16 @@ end
             @inbounds  Y[1] = -C[1,1]
             @inbounds  Y[2] = -C[2,1]
          else
-            # R = 
+            # R =
             # [ a11*f11+b11*e11 a12*f11+b11*e12 a11*f12+b12*e11 a12*f12+b12*e12]
             # [           a21*f11 a22*f11+b11*e22           a21*f12 a22*f12+b12*e22]
             # [           b21*e11           b21*e12 a11*f22+b22*e11 a12*f22+b22*e12]
-            # [                 0           b21*e22           a21*f22 a22*f22+b22*e22]                
-            # (iszero(E[1,2]) && iszero(F[1,2])) ? 
+            # [                 0           b21*e22           a21*f22 a22*f22+b22*e22]
+            # (iszero(E[1,2]) && iszero(F[1,2])) ?
             # (@inbounds R = [ A[1,1]*F[1,1]+B[1,1]*E[1,1] A[1,2]*F[1,1] B[1,2]*E[1,1] 0;
             #                A[2,1]*F[1,1] A[2,2]*F[1,1]+B[1,1]*E[2,2]           0   B[1,2]*E[2,2];
             #                B[2,1]*E[1,1]           0   A[1,1]*F[2,2]+B[2,2]*E[1,1] A[1,2]*F[2,2];
-            #                0           B[2,1]*E[2,2]           A[2,1]*F[2,2] A[2,2]*F[2,2]+B[2,2]*E[2,2]]) : 
+            #                0           B[2,1]*E[2,2]           A[2,1]*F[2,2] A[2,2]*F[2,2]+B[2,2]*E[2,2]]) :
             # (@inbounds R = [ A[1,1]*F[1,1]+B[1,1]*E[1,1] A[1,2]*F[1,1]+B[1,1]*E[1,2] A[1,1]*F[1,2]+B[1,2]*E[1,1] A[1,2]*F[1,2]+B[1,2]*E[1,2];
             #                A[2,1]*F[1,1] A[2,2]*F[1,1]+B[1,1]*E[2,2]           A[2,1]*F[1,2] A[2,2]*F[1,2]+B[1,2]*E[2,2];
             #                B[2,1]*E[1,1]           B[2,1]*E[1,2] A[1,1]*F[2,2]+B[2,2]*E[1,1] A[1,2]*F[2,2]+B[2,2]*E[1,2];
@@ -1143,9 +1143,9 @@ end
             @inbounds  R[1,1] = A[1,1]*F[1,1]+B[1,1]*E[1,1]
             @inbounds  R[1,2] = A[1,2]*F[1,1]+B[1,1]*E[1,2]
             @inbounds  R[1,3] = A[1,1]*F[1,2]+B[1,2]*E[1,1]
-            @inbounds  R[1,4] = A[1,2]*F[1,2]+B[1,2]*E[1,2] 
+            @inbounds  R[1,4] = A[1,2]*F[1,2]+B[1,2]*E[1,2]
             @inbounds  R[2,1] = A[2,1]*F[1,1]
-            @inbounds  R[2,2] = A[2,2]*F[1,1]+B[1,1]*E[2,2] 
+            @inbounds  R[2,2] = A[2,2]*F[1,1]+B[1,1]*E[2,2]
             @inbounds  R[2,3] = A[2,1]*F[1,2]
             @inbounds  R[2,4] = A[2,2]*F[1,2]+B[1,2]*E[2,2]
             @inbounds  R[3,1] = B[2,1]*E[1,1]
@@ -1296,11 +1296,11 @@ function lyapds!(A::Matrix{T1},C::Matrix{T1}; adj = false) where {T1<:BlasReal}
                  #y += C[ic,k]'*A[ic,l]
                  mul!(y,transpose(view(C,ic,k)),view(A,ic,l),ONE,ONE)
                end
-              if kk == ll 
+              if kk == ll
                  lyapd2!(adj,y,dk,view(A,k,k),Xw,Yw)
                  copyto!(Ckl,y)
                else
-                 lyapdsylv2!(adj,y,dk,dl,view(A,k,k),view(A,l,l),Xw,Yw)  
+                 lyapdsylv2!(adj,y,dk,dl,view(A,k,k),view(A,l,l),Xw,Yw)
                  copyto!(Ckl,y)
                end
                j += dl
@@ -1352,11 +1352,11 @@ function lyapds!(A::Matrix{T1},C::Matrix{T1}; adj = false) where {T1<:BlasReal}
                  # y += (A[k,ic]*C[ic,l])'
                  mul!(y,transpose(view(C,ic,l)),transpose(view(A,k,ic)),ONE,ONE)
               end
-              if i == j 
+              if i == j
                  lyapd2!(adj,y,dk,view(A,k,k),Xw,Yw)
                  copyto!(Clk,y)
               else
-                 lyapdsylv2!(adj,y,dl,dk,view(A,l,l),view(A,k,k),Xw,Yw)  
+                 lyapdsylv2!(adj,y,dl,dk,view(A,l,l),view(A,k,k),Xw,Yw)
                  copyto!(Clk,y)
               end
               i -= dk
@@ -1382,7 +1382,7 @@ function lyapd2!(adj,C::AbstractMatrix{T},na::Int,A::AbstractMatrix{T},Xw::Abstr
    #      A'*X*A - X = -C if adj = true  -> R = kron(A',A')-I = (kron(A,A)-I)'
    #      A*X*A' - X = -C if adj = false -> R = kron(A,A)-I
    MONE = -one(T)
-   if na == 1 
+   if na == 1
       temp = A[1,1]^2+MONE
       rmul!(C,inv(-temp))
       any(!isfinite, C) && throw("ME:SingularException: A has eigenvalue(s) with moduli ≈ 1")
@@ -1396,13 +1396,13 @@ function lyapd2!(adj,C::AbstractMatrix{T},na::Int,A::AbstractMatrix{T},Xw::Abstr
    @inbounds  Y[2] = -C[2,1]
    @inbounds  Y[3] = -C[2,2]
    if adj
-      # Rt = 
+      # Rt =
       # [ a11^2-1              2*a11*a21      a21^2]
       # [   a11*a12  a11*a22+a12*a21-1    a21*a22]
       # [     a12^2              2*a12*a22  a22^2-1]
       # @inbounds R = [ A[1,1]^2+MONE    TWO*A[1,1]*A[2,1]         A[2,1]^2;
       #                 A[1,1]*A[1,2]    A[1,1]*A[2,2]+A[1,2]*A[2,1]+MONE  A[2,1]*A[2,2];
-      #                 A[1,2]^2         TWO*A[1,2]*A[2,2]         A[2,2]^2+MONE ] 
+      #                 A[1,2]^2         TWO*A[1,2]*A[2,2]         A[2,2]^2+MONE ]
       @inbounds  R[1,1] = A[1,1]^2+MONE
       @inbounds  R[1,2] = TWO*A[1,1]*A[2,1]
       @inbounds  R[1,3] = A[2,1]^2
@@ -1413,14 +1413,14 @@ function lyapd2!(adj,C::AbstractMatrix{T},na::Int,A::AbstractMatrix{T},Xw::Abstr
       @inbounds  R[3,2] = TWO*A[1,2]*A[2,2]
       @inbounds  R[3,3] = A[2,2]^2+MONE
    else
-      # R = 
+      # R =
       # [ a11^2-1              2*a11*a12      a12^2]
       # [   a11*a21  a11*a22+a12*a21-1    a12*a22]
       # [     a21^2              2*a21*a22  a22^2-1]
-       
+
       # @inbounds R = [ A[1,1]^2+MONE    TWO*A[1,1]*A[1,2]         A[1,2]^2;
       #                 A[1,1]*A[2,1]    A[1,1]*A[2,2]+A[1,2]*A[2,1]+MONE  A[1,2]*A[2,2];
-      #                 A[2,1]^2         TWO*A[2,1]*A[2,2]         A[2,2]^2+MONE ] 
+      #                 A[2,1]^2         TWO*A[2,1]*A[2,2]         A[2,2]^2+MONE ]
       @inbounds  R[1,1] = A[1,1]^2+MONE
       @inbounds  R[1,2] = TWO*A[1,1]*A[1,2]
       @inbounds  R[1,3] = A[1,2]^2
@@ -1439,8 +1439,8 @@ function lyapd2!(adj,C::AbstractMatrix{T},na::Int,A::AbstractMatrix{T},Xw::Abstr
    return C
 end
 function lyapdsylv2!(adj::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::AbstractMatrix{T},B::AbstractMatrix{T},Xw::AbstractMatrix{T},Yw::AbstractVector{T}) where T <:BlasReal
-#    # speed and reduced allocation oriented implementation of a solver for 1x1 and 2x2 Sylvester equations 
-#    # encountered in solving discrete Lyapunov equations: 
+#    # speed and reduced allocation oriented implementation of a solver for 1x1 and 2x2 Sylvester equations
+#    # encountered in solving discrete Lyapunov equations:
 #    #      A'*X*B - X = -C if adj = true  -> R = kron(B',A') - I = (kron(B,A)-I)'
 #    #      A*X*B' - X = -C if adj = false -> R = kron(B,A)-I
 
@@ -1457,7 +1457,7 @@ function lyapdsylv2!(adj::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::AbstractM
    if adj
       # @inbounds  R = kron(transpose(B),transpose(A)) - I
       if na == 1
-         # R12t = 
+         # R12t =
          # [ a11*b11-1      a11*b21]
          # [     a11*b12  a11*b22-1]
          # @inbounds R = [ A[1,1]*B[1,1]+MONE      A[1,1]*B[2,1];
@@ -1470,7 +1470,7 @@ function lyapdsylv2!(adj::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::AbstractM
          @inbounds  Y[2] = -C[1,2]
    else
          if nb == 1
-            # R21t = 
+            # R21t =
             # [ a11*b11-1      a21*b11]
             # [     a12*b11  a22*b11-1]
             # @inbounds R = [ A[1,1]*B[1,1]+MONE      A[2,1]*B[1,1];
@@ -1482,7 +1482,7 @@ function lyapdsylv2!(adj::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::AbstractM
             @inbounds  Y[1] = -C[1,1]
             @inbounds  Y[2] = -C[2,1]
          else
-            # Rt = 
+            # Rt =
             # [ a11*b11-1      a21*b11      a11*b21      a21*b21]
             # [     a12*b11  a22*b11-1      a12*b21      a22*b21]
             # [     a11*b12      a21*b12  a11*b22-1      a21*b22]
@@ -1541,7 +1541,7 @@ function lyapdsylv2!(adj::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::AbstractM
             @inbounds  Y[1] = -C[1,1]
             @inbounds  Y[2] = -C[2,1]
          else
-            # R = 
+            # R =
             # [ a11*b11-1      a12*b11      a11*b12      a12*b12]
             # [     a21*b11  a22*b11-1      a21*b12      a22*b12]
             # [     a11*b21      a12*b21  a11*b22-1      a12*b22]
@@ -1599,7 +1599,7 @@ function lyapds!(A::Matrix{T1},C::Matrix{T1}; adj = false) where {T1<:BlasComple
                end
             end
             temp = ONE-A[k,k]'*A[l,l]
-            C[k,l] = y/temp 
+            C[k,l] = y/temp
             isfinite(C[k,l]) || throw("ME:SingularException: A has eigenvalues α and β such that αβ ≈ 1")
             k == l && (C[k,k] = real(C[k,k]))
             if l < k
@@ -1624,7 +1624,7 @@ function lyapds!(A::Matrix{T1},C::Matrix{T1}; adj = false) where {T1<:BlasComple
                end
             end
             temp = ONE-A[k,k]'*A[l,l]
-            C[l,k] = y/temp 
+            C[l,k] = y/temp
             isfinite(C[l,k]) || throw("ME:SingularException: A has eigenvalues α and β such that αβ ≈ 1")
             k == l && (C[k,k] = real(C[k,k]))
             if k > l
@@ -1718,11 +1718,11 @@ function lyapds!(A::Matrix{T1},E::Union{Matrix{T1},UniformScaling{Bool}}, C::Mat
                  mul!(y,transpose(view(C,ic,k)),view(A,ic,l),ONE,ONE)
                  mul!(y,transpose(view(W,ic,dkk)),view(E,ic,l),MONE,ONE)
              end
-             if i == j 
-                lyapd2!(adj,y,dk,view(A,k,k),view(E,k,k),Xw,Yw)   
+             if i == j
+                lyapd2!(adj,y,dk,view(A,k,k),view(E,k,k),Xw,Yw)
                 copyto!(Ckl,y)
              else
-                lyapdsylv2!(adj,y,dk,dl,view(A,k,k),view(E,k,k),view(A,l,l),view(E,l,l),Xw,Yw)  
+                lyapdsylv2!(adj,y,dk,dl,view(A,k,k),view(E,k,k),view(A,l,l),view(E,l,l),Xw,Yw)
                 copyto!(Ckl,y)
              end
              j += dl
@@ -1788,11 +1788,11 @@ function lyapds!(A::Matrix{T1},E::Union{Matrix{T1},UniformScaling{Bool}}, C::Mat
                mul!(y,transpose(view(C,ic,l)),transpose(view(A,k,ic)),ONE,ONE)
                mul!(y,transpose(view(W,ic,dll)),transpose(view(E,k,ic)),MONE,ONE)
             end
-            if i == j 
-               lyapd2!(adj,y,dk,view(A,k,k),view(E,k,k),Xw,Yw)   
+            if i == j
+               lyapd2!(adj,y,dk,view(A,k,k),view(E,k,k),Xw,Yw)
                copyto!(Clk,y)
             else
-               lyapdsylv2!(adj,y,dl,dk,view(A,l,l),view(E,l,l),view(A,k,k),view(E,k,k),Xw,Yw)  
+               lyapdsylv2!(adj,y,dl,dk,view(A,l,l),view(E,l,l),view(A,k,k),view(E,k,k),Xw,Yw)
                copyto!(Clk,y)
             end
             i -= dk
@@ -1819,7 +1819,7 @@ end
    #      A'*X*A - E'*X*E = -C if adj = true  -> R = kron(A',A')-kron(E',E') = (kron(A,A)-kron(E,E))'
    #      A*X*A' - E*X*E' = -C if adj = false -> R = kron(A,A)-kron(E,E)
    MONE = -one(T)
-   if na == 1 
+   if na == 1
       temp = E[1,1]^2-A[1,1]^2
       rmul!(C,inv(temp))
       any(!isfinite, C) &&  throw("ME:SingularException: A-λE has eigenvalue(s) with moduli equal to one")
@@ -1833,20 +1833,20 @@ end
    @inbounds  Y[2] = -C[2,1]
    @inbounds  Y[3] = -C[2,2]
    if adj
-      # Rt = 
+      # Rt =
       # [     a11^2 - e11^2,                   2*a11*a21,         a21^2]
       # [ a11*a12 - e11*e12, a11*a22 + a12*a21 - e11*e22,       a21*a22]
       # [     a12^2 - e12^2,       2*a12*a22 - 2*e12*e22, a22^2 - e22^2]
-      # iszero(E[1,2]) ? 
+      # iszero(E[1,2]) ?
       #    (@inbounds R = [ A[1,1]^2-E[1,1]^2    TWO*A[1,1]*A[2,1]         A[2,1]^2;
       #                 A[1,1]*A[1,2]    A[1,1]*A[2,2]+A[1,2]*A[2,1]-E[1,1]*E[2,2]  A[2,1]*A[2,2];
       #                 A[1,2]^2         TWO*A[1,2]*A[2,2]         A[2,2]^2-E[2,2]^2 ] ) :
          # (@inbounds R = [ A[1,1]^2-E[1,1]^2    TWO*A[1,1]*A[2,1]         A[2,1]^2;
          #              A[1,1]*A[1,2]-E[1,1]*E[1,2]    A[1,1]*A[2,2]+A[1,2]*A[2,1]-E[1,1]*E[2,2]  A[2,1]*A[2,2];
-         #              A[1,2]^2-E[1,2]^2         TWO*(A[1,2]*A[2,2]-E[1,2]*E[2,2])         A[2,2]^2-E[2,2]^2 ]) 
-      @inbounds  R[1,1] = A[1,1]^2-E[1,1]^2 
+         #              A[1,2]^2-E[1,2]^2         TWO*(A[1,2]*A[2,2]-E[1,2]*E[2,2])         A[2,2]^2-E[2,2]^2 ])
+      @inbounds  R[1,1] = A[1,1]^2-E[1,1]^2
       @inbounds  R[1,2] = TWO*A[1,1]*A[2,1]
-      @inbounds  R[1,3] = A[2,1]^2 
+      @inbounds  R[1,3] = A[2,1]^2
       @inbounds  R[2,1] = A[1,1]*A[1,2]-E[1,1]*E[1,2]
       @inbounds  R[2,2] = A[1,1]*A[2,2]+A[1,2]*A[2,1]-E[1,1]*E[2,2]
       @inbounds  R[2,3] = A[2,1]*A[2,2]
@@ -1854,21 +1854,21 @@ end
       @inbounds  R[3,2] = TWO*(A[1,2]*A[2,2]-E[1,2]*E[2,2])
       @inbounds  R[3,3] = A[2,2]^2-E[2,2]^2
    else
-      # R = 
+      # R =
       # [ a11^2 - e11^2,       2*a11*a12 - 2*e11*e12,     a12^2 - e12^2]
       # [       a11*a21, a11*a22 + a12*a21 - e11*e22, a12*a22 - e12*e22]
       # [         a21^2,                   2*a21*a22,     a22^2 - e22^2]
-      # iszero(E[1,2]) ? 
+      # iszero(E[1,2]) ?
       #    (@inbounds R = [ A[1,1]^2-E[1,1]^2    TWO*A[1,1]*A[1,2]         A[1,2]^2;
       #                 A[1,1]*A[2,1]    A[1,1]*A[2,2]+A[1,2]*A[2,1]-E[1,1]*E[2,2]  A[1,2]*A[2,2];
-      #                 A[2,1]^2         TWO*A[2,1]*A[2,2]         A[2,2]^2-E[2,2]^2 ] ) : 
-             
+      #                 A[2,1]^2         TWO*A[2,1]*A[2,2]         A[2,2]^2-E[2,2]^2 ] ) :
+
       #    (@inbounds R = [ A[1,1]^2-E[1,1]^2    TWO*(A[1,1]*A[1,2]-E[1,1]*E[1,2])         A[1,2]^2-E[1,2]^2;
       #                 A[1,1]*A[2,1]    A[1,1]*A[2,2]+A[1,2]*A[2,1]-E[1,1]*E[2,2]  A[1,2]*A[2,2]-E[1,2]*E[2,2];
       #                 A[2,1]^2         TWO*A[2,1]*A[2,2]         A[2,2]^2-E[2,2]^2 ] )
-      @inbounds  R[1,1] = A[1,1]^2-E[1,1]^2 
+      @inbounds  R[1,1] = A[1,1]^2-E[1,1]^2
       @inbounds  R[1,2] = TWO*(A[1,1]*A[1,2]-E[1,1]*E[1,2])
-      @inbounds  R[1,3] = A[1,2]^2-E[1,2]^2 
+      @inbounds  R[1,3] = A[1,2]^2-E[1,2]^2
       @inbounds  R[2,1] = A[1,1]*A[2,1]
       @inbounds  R[2,2] = A[1,1]*A[2,2]+A[1,2]*A[2,1]-E[1,1]*E[2,2]
       @inbounds  R[2,3] = A[1,2]*A[2,2]-E[1,2]*E[2,2]
@@ -1884,12 +1884,12 @@ end
    return C
 end
 @inline function lyapdsylv2!(adj,C::AbstractMatrix{T},na::Int,nb::Int,A::AbstractMatrix{T},E::AbstractMatrix{T},B::AbstractMatrix{T},F::AbstractMatrix{T},Xw::AbstractMatrix{T},Yw::StridedVector{T}) where T <:BlasReal
-   # speed and reduced allocation oriented implementation of a solver for 1x1 and 2x2 Sylvester equations 
-   # encountered in solving discrete Lyapunov equations: 
+   # speed and reduced allocation oriented implementation of a solver for 1x1 and 2x2 Sylvester equations
+   # encountered in solving discrete Lyapunov equations:
    #      A'*X*B - E'*X*F = -C if adj = true  -> R = kron(B',A') - kron(F',E') = (kron(B,A)-kron(F,E))'
    #      A*X*B' - E*X*F' = -C if adj = false -> R = kron(B,A)-kron(F,E)
    if na == 1 && nb == 1
-      temp = E[1,1]*F[1,1] - A[1,1]*B[1,1] 
+      temp = E[1,1]*F[1,1] - A[1,1]*B[1,1]
       rmul!(C,inv(temp))
       any(!isfinite, C) && throw("ME:SingularException: A-λE has eigenvalues α and β such that αβ ≈ 1")
       return C
@@ -1899,9 +1899,9 @@ end
    Y = view(Yw,i1)
    if adj
       if na == 1
-         # R12t = 
+         # R12t =
          # [ a11*b11 - e11*f11,           a11*b21]
-         # [ a11*b12 - e11*f12, a11*b22 - e11*f22]          
+         # [ a11*b12 - e11*f12, a11*b22 - e11*f22]
          # @inbounds R = [ A[1,1]*B[1,1]-E[1,1]*F[1,1]      A[1,1]*B[2,1];
          #                 A[1,1]*B[1,2]-E[1,1]*F[1,2]  A[1,1]*B[2,2]-E[1,1]*F[2,2]]
          @inbounds  R[1,1] = A[1,1]*B[1,1]-E[1,1]*F[1,1]
@@ -1914,7 +1914,7 @@ end
          if nb == 1
             # R21t =
             # [ a11*b11 - e11*f11,           a21*b11]
-            # [ a12*b11 - e12*f11, a22*b11 - e22*f11]            
+            # [ a12*b11 - e12*f11, a22*b11 - e22*f11]
             # @inbounds R = [ A[1,1]*B[1,1]-E[1,1]*F[1,1]      A[2,1]*B[1,1];
             #                 A[1,2]*B[1,1]-E[1,2]*F[1,1]  A[2,2]*B[1,1]-E[2,2]*F[1,1] ]
             @inbounds  R[1,1] = A[1,1]*B[1,1]-E[1,1]*F[1,1]
@@ -1924,31 +1924,31 @@ end
             @inbounds  Y[1] = -C[1,1]
             @inbounds  Y[2] = -C[2,1]
          else
-            # Rt = 
+            # Rt =
             # [ a11*b11 - e11*f11,           a21*b11,           a11*b21,           a21*b21]
             # [ a12*b11 - e12*f11, a22*b11 - e22*f11,           a12*b21,           a22*b21]
             # [ a11*b12 - e11*f12,           a21*b12, a11*b22 - e11*f22,           a21*b22]
             # [ a12*b12 - e12*f12, a22*b12 - e22*f12, a12*b22 - e12*f22, a22*b22 - e22*f22]
-            # (iszero(E[1,2]) && iszero(F[1,2])) ?   
+            # (iszero(E[1,2]) && iszero(F[1,2])) ?
             # (@inbounds R = [ A[1,1]*B[1,1]-E[1,1]*F[1,1]      A[2,1]*B[1,1]      A[1,1]*B[2,1]      A[2,1]*B[2,1];
             # A[1,2]*B[1,1]  A[2,2]*B[1,1]-E[2,2]*F[1,1]      A[1,2]*B[2,1]      A[2,2]*B[2,1];
             # A[1,1]*B[1,2]      A[2,1]*B[1,2]  A[1,1]*B[2,2]-E[1,1]*F[2,2]      A[2,1]*B[2,2];
-            # A[1,2]*B[1,2]      A[2,2]*B[1,2]      A[1,2]*B[2,2]  A[2,2]*B[2,2]-E[2,2]*F[2,2]]) : 
+            # A[1,2]*B[1,2]      A[2,2]*B[1,2]      A[1,2]*B[2,2]  A[2,2]*B[2,2]-E[2,2]*F[2,2]]) :
             # (@inbounds R = [ A[1,1]*B[1,1]-E[1,1]*F[1,1]      A[2,1]*B[1,1]      A[1,1]*B[2,1]      A[2,1]*B[2,1];
             # A[1,2]*B[1,1]-E[1,1]*F[1,2]  A[2,2]*B[1,1]-E[2,2]*F[1,1]      A[1,2]*B[2,1]      A[2,2]*B[2,1];
             # A[1,1]*B[1,2]-E[1,1]*F[1,2]      A[2,1]*B[1,2]  A[1,1]*B[2,2]-E[1,1]*F[2,2]      A[2,1]*B[2,2];
-            # A[1,2]*B[1,2]-E[1,2]*F[1,2]      A[2,2]*B[1,2]-E[2,2]*F[1,2]      A[1,2]*B[2,2]-E[1,2]*F[2,2]  A[2,2]*B[2,2]-E[2,2]*F[2,2]])  
+            # A[1,2]*B[1,2]-E[1,2]*F[1,2]      A[2,2]*B[1,2]-E[2,2]*F[1,2]      A[1,2]*B[2,2]-E[1,2]*F[2,2]  A[2,2]*B[2,2]-E[2,2]*F[2,2]])
             @inbounds  R[1,1] = A[1,1]*B[1,1]-E[1,1]*F[1,1]
             @inbounds  R[1,2] = A[2,1]*B[1,1]
             @inbounds  R[1,3] = A[1,1]*B[2,1]
             @inbounds  R[1,4] = A[2,1]*B[2,1]
             @inbounds  R[2,1] = A[1,2]*B[1,1]-E[1,1]*F[1,2]
-            @inbounds  R[2,2] = A[2,2]*B[1,1]-E[2,2]*F[1,1] 
+            @inbounds  R[2,2] = A[2,2]*B[1,1]-E[2,2]*F[1,1]
             @inbounds  R[2,3] = A[1,2]*B[2,1]
             @inbounds  R[2,4] = A[2,2]*B[2,1]
             @inbounds  R[3,1] = A[1,1]*B[1,2]-E[1,1]*F[1,2]
             @inbounds  R[3,2] = A[2,1]*B[1,2]
-            @inbounds  R[3,3] = A[1,1]*B[2,2]-E[1,1]*F[2,2] 
+            @inbounds  R[3,3] = A[1,1]*B[2,2]-E[1,1]*F[2,2]
             @inbounds  R[3,4] = A[2,1]*B[2,2]
             @inbounds  R[4,1] = A[1,2]*B[1,2]-E[1,2]*F[1,2]
             @inbounds  R[4,2] = A[2,2]*B[1,2]-E[2,2]*F[1,2]
@@ -1962,7 +1962,7 @@ end
       end
    else
       if na == 1
-         # R12 = 
+         # R12 =
          # [ a11*b11 - e11*f11, a11*b12 - e11*f12]
          # [           a11*b21, a11*b22 - e11*f22]
          # @inbounds R = [ A[1,1]*B[1,1]-E[1,1]*F[1,1]      A[1,1]*B[1,2]-E[1,1]*F[1,2];
@@ -1975,7 +1975,7 @@ end
          @inbounds  Y[2] = -C[1,2]
       else
          if nb == 1
-            # R21 = 
+            # R21 =
             # [ a11*b11 - e11*f11, a12*b11 - e12*f11]
             # [           a21*b11, a22*b11 - e22*f11]
             # @inbounds R = [ A[1,1]*B[1,1]-E[1,1]*F[1,1]      A[1,2]*B[1,1]-E[1,2]*F[1,1];
@@ -1987,31 +1987,31 @@ end
             @inbounds  Y[1] = -C[1,1]
             @inbounds  Y[2] = -C[2,1]
          else
-            # R = 
+            # R =
             # [ a11*b11 - e11*f11, a12*b11 - e12*f11, a11*b12 - e11*f12, a12*b12 - e12*f12]
             # [           a21*b11, a22*b11 - e22*f11,           a21*b12, a22*b12 - e22*f12]
             # [           a11*b21,           a12*b21, a11*b22 - e11*f22, a12*b22 - e12*f22]
             # [           a21*b21,           a22*b21,           a21*b22, a22*b22 - e22*f22]
-            # (iszero(E[1,2]) && iszero(F[1,2])) ?   
+            # (iszero(E[1,2]) && iszero(F[1,2])) ?
             # (@inbounds R = [ A[1,1]*B[1,1]-E[1,1]*F[1,1]      A[1,2]*B[1,1]      A[1,1]*B[1,2]      A[1,2]*B[1,2];
             # A[2,1]*B[1,1]  A[2,2]*B[1,1]-E[2,2]*F[1,1]      A[2,1]*B[1,2]      A[2,2]*B[1,2];
             # A[1,1]*B[2,1]      A[1,2]*B[2,1]  A[1,1]*B[2,2]-E[1,1]*F[2,2]      A[1,2]*B[2,2];
-            # A[2,1]*B[2,1]      A[2,2]*B[2,1]      A[2,1]*B[2,2]  A[2,2]*B[2,2]-E[2,2]*F[2,2]]) : 
+            # A[2,1]*B[2,1]      A[2,2]*B[2,1]      A[2,1]*B[2,2]  A[2,2]*B[2,2]-E[2,2]*F[2,2]]) :
             # (@inbounds R = [ A[1,1]*B[1,1]-E[1,1]*F[1,1]      A[1,2]*B[1,1]-E[1,2]*F[1,1]      A[1,1]*B[1,2]-E[1,1]*F[1,2]      A[1,2]*B[1,2]-E[1,2]*F[1,2];
             # A[2,1]*B[1,1]  A[2,2]*B[1,1]-E[2,2]*F[1,1]      A[2,1]*B[1,2]      A[2,2]*B[1,2]-E[2,2]*F[1,2];
             # A[1,1]*B[2,1]      A[1,2]*B[2,1]  A[1,1]*B[2,2]-E[1,1]*F[2,2]      A[1,2]*B[2,2]-E[1,2]*F[2,2];
             # A[2,1]*B[2,1]      A[2,2]*B[2,1]      A[2,1]*B[2,2]  A[2,2]*B[2,2]-E[2,2]*F[2,2]])
             @inbounds  R[1,1] = A[1,1]*B[1,1]-E[1,1]*F[1,1]
             @inbounds  R[1,2] = A[1,2]*B[1,1]-E[1,2]*F[1,1]
-            @inbounds  R[1,3] = A[1,1]*B[1,2]-E[1,1]*F[1,2] 
+            @inbounds  R[1,3] = A[1,1]*B[1,2]-E[1,1]*F[1,2]
             @inbounds  R[1,4] = A[1,2]*B[1,2]-E[1,2]*F[1,2]
             @inbounds  R[2,1] = A[2,1]*B[1,1]
-            @inbounds  R[2,2] = A[2,2]*B[1,1]-E[2,2]*F[1,1] 
+            @inbounds  R[2,2] = A[2,2]*B[1,1]-E[2,2]*F[1,1]
             @inbounds  R[2,3] = A[2,1]*B[1,2]
             @inbounds  R[2,4] = A[2,2]*B[1,2]-E[2,2]*F[1,2]
             @inbounds  R[3,1] = A[1,1]*B[2,1]
             @inbounds  R[3,2] = A[1,2]*B[2,1]
-            @inbounds  R[3,3] = A[1,1]*B[2,2]-E[1,1]*F[2,2] 
+            @inbounds  R[3,3] = A[1,1]*B[2,2]-E[1,1]*F[2,2]
             @inbounds  R[3,4] = A[1,2]*B[2,2]-E[1,2]*F[2,2]
             @inbounds  R[4,1] = A[2,1]*B[2,1]
             @inbounds  R[4,2] = A[2,2]*B[2,1]

--- a/src/meoperators.jl
+++ b/src/meoperators.jl
@@ -3,182 +3,171 @@ abstract type SylvesterMatrixEquationsMaps{T} <: LinearMaps.LinearMap{T} end
 const MatrixEquationsMaps{T} = Union{LyapunovMatrixEquationsMaps{T}, SylvesterMatrixEquationsMaps{T} }
 
 """
-    M = trmatop(n, m) 
+    M = trmatop(n, m)
 
 Define the transposition operator `M: X -> X'` for all `n x m` matrices.
 """
 struct trmatop{Int} <: LinearMaps.LinearMap{Int}
-    size::Dims{2}
-    function trmatop(dims::Dims{2}) where {T}
-        all(≥(0), dims) || throw(ArgumentError("dims must be non-negative"))
-        return new{Int}(dims)
-    end
-    function trmatop(m::Int,n::Int) where {T}
-      (m ≥(0) & n ≥(0))  || throw(ArgumentError("dimensions must be non-negative"))
-      return new{Int}((m,n))
-    end
+   size::Dims{2}
+   function trmatop(dims::Dims{2}) where {T}
+      all(≥(0), dims) || throw(ArgumentError("dims must be non-negative"))
+      return new{Int}(dims)
+   end
+   function trmatop(m::Int, n::Int) where {T}
+      (m ≥ (0) & n ≥ (0))  || throw(ArgumentError("dimensions must be non-negative"))
+      return new{Int}((m, n))
+   end
 end
-trmatop(n::Int) = trmatop(n,n)
-Base.size(A::trmatop) = (prod(A.size),prod(A.size))
+trmatop(n::Int) = trmatop(n, n)
+Base.size(A::trmatop) = (prod(A.size), prod(A.size))
 LinearAlgebra.issymmetric(A::trmatop) = A.size[1] == A.size[2]
 LinearAlgebra.ishermitian(A::trmatop) = A.size[1] == A.size[2]
-function LinearAlgebra.mul!(y::AbstractVector, A::trmatop, x::AbstractVector)
-    X = reshape(x, A.size...)
-    LinearMaps.check_dim_mul(y, A, x)
-    y[:] = adjoint(X)[:]
-    return y[:]
+function mul!(y::AbstractVector, A::trmatop, x::AbstractVector)
+   X = reshape(x, A.size...)
+   LinearMaps.check_dim_mul(y, A, x)
+   copyto!(y, adjoint(X))
+   return y
 end
+
 """
-    M = trmatop(A) 
+    M = trmatop(A)
 
 Define the transposition operator `M: X -> X'` of all matrices of the size of `A`.
 """
 trmatop(A) = trmatop(size(A))
-struct LyapunovMap{T} <: LyapunovMatrixEquationsMaps{T}
-  A::AbstractMatrix
-  disc::Bool
-  her::Bool
-  adj::Bool
-  function LyapunovMap(A::AbstractMatrix{T}; disc = false, her = false) where {T}
+
+struct LyapunovMap{T,TA<:AbstractMatrix} <: LyapunovMatrixEquationsMaps{T}
+   A::TA
+   disc::Bool
+   her::Bool
+   adj::Bool
+   function LyapunovMap(A::AbstractMatrix{T}; disc=false, her=false) where {T}
       LinearAlgebra.checksquare(A)
-      return new{T}(A, disc, her, isa(A,Adjoint))
-  end
+      return new{T,typeof(A)}(A, disc, her, isa(A, Adjoint))
+   end
 end
+
 """
-    L = lyapop(A; disc = false, her = false) 
+    L = lyapop(A; disc = false, her = false)
 
 Define, for an `n x n` matrix `A`, the continuous Lyapunov operator `L:X -> AX+XA'`
 if `disc = false` or the discrete Lyapunov operator `L:X -> AXA'-X` if `disc = true`.
 If `her = false` the Lyapunov operator `L:X -> Y` maps general square matrices `X`
-into general square matrices `Y`, and the associated matrix `M = Matrix(L)` is 
+into general square matrices `Y`, and the associated matrix `M = Matrix(L)` is
 ``n^2 \\times n^2``.
 If `her = true` the Lyapunov operator `L:X -> Y` maps symmetric/Hermitian matrices `X`
-into symmetric/Hermitian matrices `Y`, and the associated matrix `M = Matrix(L)` is 
+into symmetric/Hermitian matrices `Y`, and the associated matrix `M = Matrix(L)` is
 ``n(n+1)/2 \\times n(n+1)/2``.
 For the definitions of the Lyapunov operators see:
 
 M. Konstantinov, V. Mehrmann, P. Petkov. On properties of Sylvester and Lyapunov
 operators. Linear Algebra and its Applications 312:35–71, 2000.
 """
-function lyapop(A::AbstractMatrix{T}; disc = false, her = false) where T
-    LyapunovMap(A; disc = disc, her = her)
+function lyapop(A::AbstractMatrix; disc=false, her=false)
+   LyapunovMap(A; disc=disc, her=her)
 end
-lyapop(A::Schur{T,Matrix{T}}; kwargs...) where T = LyapunovMap(A.T; kwargs...)
-lyapop(A::Number; kwargs...) = LyapunovMap(A*ones(eltype(A),1,1); kwargs...) 
+lyapop(A::Schur; kwargs...) = LyapunovMap(A.T; kwargs...)
+lyapop(A::Number; kwargs...) = LyapunovMap(fill(A, 1, 1); kwargs...)
 function Base.size(L::LyapunovMap)
-    n = size(L.A,1)
-    N = L.her ? Int(n*(n+1)/2) : n*n
-    return (N,N)
+   n = size(L.A, 1)
+   N = L.her ? Int(n * (n + 1) / 2) : n * n
+   return (N, N)
 end
-Base.size(L::Adjoint{<:Any, <: LyapunovMap}) = size(L.parent)
-function LinearAlgebra.mul!(y::AbstractVector, L::LyapunovMap{T}, x::AbstractVector) where T
-  n = size(L.A,1)
-  T1 = promote_type(T, eltype(x))
-  if L.her
-     T == T1 ?  X = vec2triu(x, her = true) :  X = vec2triu(convert(Vector{T1}, x), her = true)
-     if L.disc
-        # (y .= triu2vec(utqu(X,L.A') - X))
-        muldsym!(y, L.A, X)
-     else
-        mulcsym!(y, L.A, X)
-     end
-     return y
+function mul!(y::AbstractVector, L::LyapunovMap{T}, x::AbstractVector) where T
+   n = size(L.A, 1)
+   T1 = promote_type(T, eltype(x))
+   if L.her
+      T == T1 ?  X = vec2triu(x, her=true) :  X = vec2triu(convert(Vector{T1}, x), her=true)
+      if L.disc
+         # (y .= triu2vec(utqu(X,L.A') - X))
+         muldsym!(y, L.A, X)
+      else
+         mulcsym!(y, L.A, X)
+      end
+      return y
    else
-     T == T1 ? X = reshape(x, n, n) : X = reshape(convert(Vector{T1}, x), n, n)
-     if L.disc
-        # (y .= (L.A*X*L.A' - X)[:])
-        Y = reshape(y, (n, n))  
-        Y .= X 
-        temp = similar(Y, (n, n))
-        mul!(temp, X, L.A')
-        mul!(Y, L.A, temp, 1, -1)
-        return y
-     else
-        # (y[:] = (L.A*X + X*L.A')[:])
-        Y = reshape(y, (n, n))   
-        mul!(Y, X, L.A')
-        mul!(Y, L.A, X, 1, 1)
-        return y
-     end
-  end
-end 
-function  mulcsym!(y::AbstractVector, A::AbstractMatrix, X::AbstractMatrix) 
-   # A*X + X*A'
-   n = size(A,1)
-   ZERO = zero(eltype(y))
-   @inbounds  begin
-      k = 1
-      for j = 1:n
-          for i = 1:j
-             temp = ZERO
-             for l = 1:n
-                 temp += A[i,l]*X[l,j] + X[i,l]*conj(A[j,l])
-             end
-             y[k] = temp
-             k += 1
-          end
+      T == T1 ? X = reshape(x, n, n) : X = reshape(convert(Vector{T1}, x), n, n)
+      if L.disc
+         # (y .= (L.A*X*L.A' - X)[:])
+         copyto!(y, x)
+         Y = reshape(y, (n, n))
+         mul!(Y, L.A, X*L.A', 1, -1)
+         return y
+      else
+         # (y[:] = (L.A*X + X*L.A')[:])
+         Y = reshape(y, (n, n))
+         mul!(Y, X, L.A')
+         mul!(Y, L.A, X, 1, 1)
+         return y
       end
    end
-   return y
 end
-function  muldsym!(y::AbstractVector, A::AbstractMatrix, X::AbstractMatrix) 
-   # A*X*A' - X
-   n = size(A,1)
-   # t = triu(X)-diag(X)/2
-   t = UpperTriangular(X)-Diagonal(X[diagind(X)]./2)
-   Y = similar(X, n, n)
-   # Y = A*t*A'
-   mul!(Y, A*t, A') 
-   # Y + Y' - X
-   @inbounds  begin
+function mulcsym!(y::AbstractVector, A::AbstractMatrix, X::AbstractMatrix)
+   require_one_based_indexing(y, A, X)
+   # A*X + X*A'
+   n = size(A, 1)
+   ZERO = zero(eltype(y))
+   @inbounds begin
       k = 1
       for j = 1:n
          for i = 1:j
-             y[k] = Y[i,j] + conj(Y[j,i]) - X[i,j]
-             k += 1
-          end
+            temp = ZERO
+            for l = 1:n
+               temp += A[i,l] * X[l,j] + X[i,l] * conj(A[j,l])
+            end
+            y[k] = temp
+            k += 1
+         end
+      end
+   end
+   return y
+end
+function muldsym!(y::AbstractVector, A::AbstractMatrix, X::AbstractMatrix)
+   require_one_based_indexing(y, X)
+   # A*X*A' - X
+   n = size(A, 1)
+   # t = triu(X)-diag(X)/2
+   t = UpperTriangular(X) - Diagonal(X[diagind(X)] ./ 2)
+   Y = similar(X, n, n)
+   # Y = A*t*A'
+   mul!(Y, A * t, A')
+   # Y + Y' - X
+   @inbounds begin
+      k = 1
+      for j = 1:n
+         for i = 1:j
+            y[k] = Y[i,j] + conj(Y[j,i]) - X[i,j]
+            k += 1
+         end
       end
    end
    return y
 end
 
-function Base.Matrix{T}(A::LyapunovMatrixEquationsMaps) where {T}
-   A.her && A.adj && (return Matrix(A')')
-   M, N = size(A)
-   mat = Matrix{T}(undef, (M, N))
-   v = fill(zero(T), N)
-   @inbounds for i in 1:N
-       v[i] = one(T)
-       # need mul!, e.g., for TransposeMap{<:CustomMap}
-       mul!(view(mat, :, i), A, v)
-       v[i] = zero(T)
-   end
-   return mat
-end
-
-LinearAlgebra.adjoint(L::LyapunovMap{T}) where T = lyapop(L.A'; disc = L.disc, her = L.her)
-LinearAlgebra.transpose(L::LyapunovMap{T}) where T = lyapop(L.A'; disc = L.disc, her = L.her)
-struct GeneralizedLyapunovMap{T} <: LyapunovMatrixEquationsMaps{T}
-   A::AbstractMatrix
-   E::AbstractMatrix
+LinearAlgebra.adjoint(L::LyapunovMap)   = lyapop(L.A'; disc=L.disc, her=L.her)
+LinearAlgebra.transpose(L::LyapunovMap) = lyapop(L.A'; disc=L.disc, her=L.her)
+struct GeneralizedLyapunovMap{T,TA<:AbstractMatrix{T},TE<:AbstractMatrix{T}} <: LyapunovMatrixEquationsMaps{T}
+   A::TA
+   E::TE
    disc::Bool
    her::Bool
    adj::Bool
-   function GeneralizedLyapunovMap(A::AbstractMatrix{T}, E::AbstractMatrix{T}; disc = false, her = false) where {T}
-       n = LinearAlgebra.checksquare(A)
-       n == LinearAlgebra.checksquare(E) ||
-            throw(DimensionMismatch("E must be a square matrix of dimension $n"))
-       adj = isa(A,Adjoint) && isa(E,Adjoint)
-       return new{T}(A, E, disc, her, adj)
+   function GeneralizedLyapunovMap(A::AbstractMatrix{T}, E::AbstractMatrix{T}; disc=false, her=false) where {T}
+      n = LinearAlgebra.checksquare(A)
+      n == LinearAlgebra.checksquare(E) ||
+               throw(DimensionMismatch("E must be a square matrix of dimension $n"))
+      adj = isa(A, Adjoint) && isa(E, Adjoint)
+      return new{T,typeof(A),typeof(E)}(A, E, disc, her, adj)
    end
 end
+
 """
-    L = lyapop(A, E; disc = false, her = false) 
+    L = lyapop(A, E; disc = false, her = false)
 
 Define, for a pair `(A,E)` of `n x n` matrices, the continuous Lyapunov operator `L:X -> AXE'+EXA'`
 if `disc = false` or the discrete Lyapunov operator `L:X -> AXA'-EXE'` if `disc = true`.
 If `her = false` the Lyapunov operator `L:X -> Y` maps general square matrices `X`
-into general square matrices `Y`, and the associated matrix `M = Matrix(L)` is 
+into general square matrices `Y`, and the associated matrix `M = Matrix(L)` is
 ``n^2 \\times n^2``.
 If `her = true` the Lyapunov operator `L:X -> Y` maps symmetric/Hermitian matrices `X`
 into symmetric/Hermitian matrices `Y`, and the associated `M = Matrix(L)` is a
@@ -188,43 +177,42 @@ For the definitions of the Lyapunov operators see:
 M. Konstantinov, V. Mehrmann, P. Petkov. On properties of Sylvester and Lyapunov
 operators. Linear Algebra and its Applications 312:35–71, 2000.
 """
-function lyapop(A::AbstractMatrix{T}, E::AbstractMatrix{T}; disc = false, her = false) where T
-    GeneralizedLyapunovMap(A, E; disc = disc, her = her)
+function lyapop(A::AbstractMatrix{T}, E::AbstractMatrix{T}; disc=false, her=false) where T
+   GeneralizedLyapunovMap(A, E; disc=disc, her=her)
 end
-lyapop(F::GeneralizedSchur{T,Matrix{T}}; kwargs...) where T = GeneralizedLyapunovMap(F.S, F.T; kwargs...)
+lyapop(F::GeneralizedSchur; kwargs...) = GeneralizedLyapunovMap(F.S, F.T; kwargs...)
 function lyapop(A::Number, E::Number; kwargs...)
-    T = promote_type(eltype(A),eltype(E))
-    GeneralizedLyapunovMap(A*ones(T,1,1), E*ones(T,1,1); kwargs...)
+   A, E = promote(A, E)
+   GeneralizedLyapunovMap(fill(A, 1, 1), fill(E, 1, 1); kwargs...)
 end
 function lyapop(A::AbstractMatrix{T1}, E::AbstractMatrix{T2}; kwargs...) where {T1,T2}
-   T = promote_type(eltype(A),eltype(E)) 
-   GeneralizedLyapunovMap(convert(Matrix{T},A), convert(Matrix{T},E); kwargs...)
+   T = promote_type(T1, T2)
+   GeneralizedLyapunovMap(convert(AbstractMatrix{T}, A), convert(AbstractMatrix{T}, E); kwargs...)
 end
 function Base.size(L::GeneralizedLyapunovMap)
-     n = size(L.A,1)
-     N = L.her ? Int(n*(n+1)/2) : n*n
-     return (N,N)
+   n = size(L.A, 1)
+   N = L.her ? Int(n * (n + 1) / 2) : n * n
+   return (N, N)
 end
-Base.size(L::Adjoint{<:Any, <: GeneralizedLyapunovMap}) = size(L.parent)
-function LinearAlgebra.mul!(y::AbstractVector, L::GeneralizedLyapunovMap{T}, x::AbstractVector) where T
-   n = size(L.A,1)
+function mul!(y::AbstractVector, L::GeneralizedLyapunovMap{T}, x::AbstractVector) where T
+   n = size(L.A, 1)
    T1 = promote_type(T, eltype(x))
    if L.her
-      T == T1 ?  X = vec2triu(x, her = true) :  X = vec2triu(convert(Vector{T1}, x), her = true)
+      T == T1 ? X = vec2triu(x, her=true) :  X = vec2triu(convert(Vector{T1}, x), her=true)
       if L.disc
          # (y .= triu2vec(utqu(X,L.A') - utqu(X,L.E')))
          muldsym!(y, L.A, L.E, X)
       else
-         mulcsym!(y, L.A, L.E, X) 
+         mulcsym!(y, L.A, L.E, X)
       end
       return y
-    else
-      T == T1 ? X = reshape(x, n, n) : X = reshape(convert(Vector{T1}, x), n, n)
+   else
+      X = T == T1 ? reshape(x, n, n) : reshape(convert(Vector{T1}, x), n, n)
+      Y = reshape(y, (n, n))
+      temp = similar(Y, (n, n))
       if L.disc
          # (y .= (L.A*X*L.A' - L.E*X*L.E')[:])
-         Y = reshape(y, (n, n))  
-         #Y .= X 
-         temp = similar(Y, (n, n))
+         # Y .= X
          mul!(temp, X, L.A')
          mul!(Y, L.A, temp)
          mul!(temp, X, L.E')
@@ -232,8 +220,6 @@ function LinearAlgebra.mul!(y::AbstractVector, L::GeneralizedLyapunovMap{T}, x::
          return y
       else
          # (y[:] = (L.A*X*L.E' + L.E*X*L.A')[:])
-         Y = reshape(y, (n, n))   
-         temp = similar(Y, (n, n))
          mul!(temp, L.E, X)
          mul!(Y, temp, L.A')
          mul!(temp, X, L.E')
@@ -241,140 +227,141 @@ function LinearAlgebra.mul!(y::AbstractVector, L::GeneralizedLyapunovMap{T}, x::
          return y
       end
    end
-end 
-function  mulcsym!(y::AbstractVector, A::AbstractMatrix, E::AbstractMatrix, X::AbstractMatrix) 
-   # AXE' + EXA' 
-   n = size(A,1)
-   Y = similar(X, n, n) 
-   ZERO = zero(eltype(y))
-   # Y = XE' 
-   mul!(Y, X, E')
-   # AY + Y'A' 
-   @inbounds  begin
-      k = 1
-      for j = 1:n
-          for i = 1:j
-             temp = ZERO
-             for l = 1:n
-                 temp += A[i,l]*Y[l,j] + conj(Y[l,i]*A[j,l])
-             end
-             y[k] = temp
-             k += 1
-          end
-      end
-   end
-   return y
 end
-function  muldsym!(y::AbstractVector,A::AbstractMatrix, E::AbstractMatrix, X::AbstractMatrix) 
-   # AXA' - EXE' 
-   n = size(A,1)
-   # t = triu(X)-diag(X)/2
-   t = UpperTriangular(X)-Diagonal(X[diagind(X)]./2)
+function mulcsym!(y::AbstractVector, A::AbstractMatrix, E::AbstractMatrix, X::AbstractMatrix)
+   require_one_based_indexing(y, A)
+   # AXE' + EXA'
+   n = size(A, 1)
    Y = similar(X, n, n)
-   # Y = A*t*A' - E*t*E'
-   mul!(Y, A*t, A') 
-   mul!(Y, E*t, E', -1, 1)
-   # Y + Y' 
+   ZERO = zero(eltype(y))
+   # Y = XE'
+   mul!(Y, X, E')
+   # AY + Y'A'
    @inbounds  begin
       k = 1
       for j = 1:n
          for i = 1:j
-             y[k] = Y[i,j]+conj(Y[j,i])
-             k += 1
-          end
+            temp = ZERO
+            for l = 1:n
+               temp += A[i,l] * Y[l,j] + conj(Y[l,i] * A[j,l])
+            end
+            y[k] = temp
+            k += 1
+         end
       end
    end
    return y
 end
-LinearAlgebra.adjoint(L::GeneralizedLyapunovMap{T}) where T = lyapop(L.A', L.E'; disc = L.disc, her = L.her)
-LinearAlgebra.transpose(L::GeneralizedLyapunovMap{T}) where T = lyapop(L.A', L.E'; disc = L.disc, her = L.her)
-
-struct InverseLyapunovMap{T} <: LyapunovMatrixEquationsMaps{T}
-  A::AbstractMatrix
-  disc::Bool
-  her::Bool
-  adj::Bool
-  sf::Bool
-  function InverseLyapunovMap(A::AbstractMatrix{T}; disc = false, her = false) where {T <: BlasFloat}
-      LinearAlgebra.checksquare(A)
-      adj = isa(A,Adjoint)
-      schur_flag = adj ? isschur(A.parent) : isschur(A)
-      return new{T}(adj ? A.parent : A, disc, her, adj, schur_flag)
-  end
+function muldsym!(y::AbstractVector, A::AbstractMatrix, E::AbstractMatrix, X::AbstractMatrix)
+   require_one_based_indexing(y)
+   # AXA' - EXE'
+   n = size(A, 1)
+   # t = triu(X)-diag(X)/2
+   t = UpperTriangular(X) - Diagonal(X[diagind(X)] ./ 2)
+   Y = similar(X, n, n)
+   # Y = A*t*A' - E*t*E'
+   mul!(Y, A * t, A')
+   mul!(Y, E * t, E', -1, 1)
+   # Y + Y'
+   @inbounds  begin
+      k = 1
+      for j = 1:n
+         for i = 1:j
+            y[k] = Y[i,j] + conj(Y[j,i])
+            k += 1
+         end
+      end
+   end
+   return y
 end
+LinearAlgebra.adjoint(L::GeneralizedLyapunovMap)   = lyapop(L.A', L.E'; disc=L.disc, her=L.her)
+LinearAlgebra.transpose(L::GeneralizedLyapunovMap) = lyapop(L.A', L.E'; disc=L.disc, her=L.her)
+
+struct InverseLyapunovMap{T,TA<:AbstractMatrix} <: LyapunovMatrixEquationsMaps{T}
+   A::TA
+   disc::Bool
+   her::Bool
+   adj::Bool
+   sf::Bool
+   function InverseLyapunovMap(A::AbstractMatrix{T}; disc=false, her=false) where {T <: BlasFloat}
+      LinearAlgebra.checksquare(A)
+      adj = isa(A, Adjoint)
+      schur_flag = adj ? isschur(A.parent) : isschur(A)
+      a = adj ? A.parent : A
+      return new{T,typeof(a)}(a, disc, her, adj, schur_flag)
+   end
+end
+
 """
-    LINV = invlyapop(A; disc = false, her = false) 
+    LINV = invlyapop(A; disc = false, her = false)
 
 Define `LINV`, the inverse of the continuous Lyapunov operator `L:X -> AX+XA'` for `disc = false`
 or the inverse of the discrete Lyapunov operator `L:X -> AXA'-X` for `disc = true`, where
 `A` is an `n x n` matrix.
 If `her = false` the inverse Lyapunov operator `LINV:Y -> X` maps general square matrices `Y`
-into general square matrices `X`, and the associated matrix `M = Matrix(LINV)` is 
+into general square matrices `X`, and the associated matrix `M = Matrix(LINV)` is
 ``n^2 \\times n^2``.
 If `her = true` the inverse Lyapunov operator `LINV:Y -> X` maps symmetric/Hermitian matrices `Y`
-into symmetric/Hermitian matrices `X`, and the associated matrix `M = Matrix(LINV)` is 
+into symmetric/Hermitian matrices `X`, and the associated matrix `M = Matrix(LINV)` is
 ``n(n+1)/2 \\times n(n+1)/2``.
 For the definitions of the Lyapunov operators see:
 
 M. Konstantinov, V. Mehrmann, P. Petkov. On properties of Sylvester and Lyapunov
 operators. Linear Algebra and its Applications 312:35–71, 2000.
 """
-function invlyapop(A::AbstractMatrix{T}; disc = false, her = false) where {T <: BlasFloat}
-    InverseLyapunovMap(A; disc = disc, her = her)
+function invlyapop(A::AbstractMatrix{T}; disc=false, her=false) where {T <: BlasFloat}
+   InverseLyapunovMap(A; disc = disc, her = her)
 end
-function invlyapop(A::AbstractMatrix; disc = false, her = false) 
-   T = eltype(A)
-   T <: BlasFloat || (T = promote_type(T, Float64) )
-   InverseLyapunovMap(T.(A); disc = disc, her = her)     
+function invlyapop(A::AbstractMatrix; disc=false, her=false) 
+   InverseLyapunovMap(convert(AbstractMatrix{promote_type(eltype(A),Float64)}, A); disc = disc, her = her)     
 end
-invlyapop(A::Schur{T,Matrix{T}}; kwargs...) where {T <: BlasFloat} = InverseLyapunovMap(A.T; kwargs...)
+invlyapop(A::Schur{<:BlasFloat}; kwargs...) = InverseLyapunovMap(A.T; kwargs...)
 function Base.size(L::InverseLyapunovMap)
-    n = size(L.A,1)
-    N = L.her ? Int(n*(n+1)/2) : n*n
-    return (N,N)
+   n = size(L.A,1)
+   N = L.her ? Int(n*(n+1)/2) : n*n
+   return (N,N)
 end
-Base.size(L::Adjoint{<:Any, <: InverseLyapunovMap}) = size(L.parent)
-function LinearAlgebra.mul!(y::AbstractVector, L::InverseLyapunovMap{T}, x::AbstractVector) where {T <: BlasFloat}
-  n = size(L.A,1)
-  T1 = promote_type(T, eltype(x))
-  y = try
-    if L.sf
-       if L.her
-          T1 == eltype(x) ? Y = vec2triu(-x, her = true) : Y = vec2triu(-convert(Vector{T1},x), her = true)
-          L.disc ? lyapds!(L.A, Y; adj = L.adj) : lyapcs!(L.A, Y; adj = L.adj)
-          y .= triu2vec(Y)
-       else
-          if L.disc
-            T1 == eltype(x) ? Y = reshape(-x, n, n) : Y = reshape(convert(Vector{T1}, -x), n, n)
-            L.adj ? sylvds!(-L.A, L.A, Y, adjA = true) : sylvds!(-L.A, L.A, Y, adjB = true)
-          else
-            T1 == eltype(x) ? Y = copy(reshape(x, n, n)) : Y = reshape(convert(Vector{T1}, x), n, n)
-           L.adj ? (sylvcs!(L.A, L.A, Y, adjA = true)) : (sylvcs!(L.A, L.A, Y, adjB = true))
-          end
-          y .= Y[:]
-       end
-    else
-       if L.her
-          T1 == eltype(x) ? Y = vec2triu(-x, her = true) : Y = vec2triu(-convert(Vector{T1},x), her = true)
-          if L.disc
-             L.adj ? (y .= triu2vec(lyapd(L.A',Y))) : (y .= triu2vec(lyapd(L.A,Y)))
-          else
-             L.adj ? (y .= triu2vec(lyapc(L.A',Y))) : (y .= triu2vec(lyapc(L.A,Y)))
-          end
-       else
-          T1 == eltype(x) ? Y = reshape(-x, n, n) : Y = reshape(convert(Vector{T1}, -x), n, n)
-          if L.disc
-             L.adj ? (y .= lyapd(L.A',Y)[:]) : (y .= lyapd(L.A,Y)[:])
-          else
-             L.adj ? (y .= lyapc(L.A',Y)[:]) : (y .= lyapc(L.A,Y)[:])
+function mul!(y::AbstractVector, L::InverseLyapunovMap{T}, x::AbstractVector) where {T <: BlasFloat}
+   n = size(L.A,1)
+   T1 = promote_type(T, eltype(x))
+   try
+      if L.sf
+         if L.her
+            Y = vec2triu(T1 == eltype(x) ? -x : -convert(Vector{T1},x), her = true)
+            L.disc ? lyapds!(L.A, Y; adj = L.adj) : lyapcs!(L.A, Y; adj = L.adj)
+            copyto!(y, triu2vec(Y))
+         else
+            if L.disc
+               Y = reshape(T1 == eltype(x) ? -x : convert(Vector{T1}, -x), n, n)
+               L.adj ? sylvds!(-L.A, L.A, Y, adjA = true) : sylvds!(-L.A, L.A, Y, adjB = true)
+            else
+               Y = T1 == eltype(x) ? copy(reshape(x, n, n)) : reshape(convert(Vector{T1}, x), n, n)
+               L.adj ? (sylvcs!(L.A, L.A, Y, adjA = true)) : (sylvcs!(L.A, L.A, Y, adjB = true))
+            end
+            copyto!(y, Y)
          end
-       end
-    end
-  catch err
-    findfirst("SingularException",string(err)) === nothing &&
-    findfirst("LAPACKException",string(err)) === nothing ? rethrow() : throw("ME:SingularException: Singular operator")
-  end
-  return y
+      else
+         if L.her
+            Y = vec2triu(T1 == eltype(x) ? -x : -convert(Vector{T1}, x) , her = true)
+            if L.disc
+               L.adj ? (y .= triu2vec(lyapd(L.A', Y))) : (y .= triu2vec(lyapd(L.A, Y)))
+            else
+               L.adj ? (y .= triu2vec(lyapc(L.A', Y))) : (y .= triu2vec(lyapc(L.A, Y)))
+            end
+         else
+            Y = reshape(T1 == eltype(x) ? -x : convert(Vector{T1}, -x), n, n)
+            if L.disc
+               copyto!(y, lyapd(L.adj ? L.A' : L.A, Y))
+            else
+               copyto!(y, lyapc(L.adj ? L.A' : L.A, Y))
+            end
+         end
+      end
+   catch err
+      findfirst("SingularException", string(err)) === nothing &&
+      findfirst("LAPACKException", string(err)) === nothing ? rethrow() : throw("ME:SingularException: Singular operator")
+   end
+   return y
 end
 LinearAlgebra.adjoint(L::InverseLyapunovMap{T}) where T = invlyapop(L.adj ? L.A : L.A'; disc = L.disc, her = L.her)
 function LinearAlgebra.transpose(L::InverseLyapunovMap{T}) where T
@@ -392,269 +379,261 @@ struct InverseGeneralizedLyapunovMap{T} <: LyapunovMatrixEquationsMaps{T}
   sf::Bool
   function InverseGeneralizedLyapunovMap(A::AbstractMatrix{T}, E::AbstractMatrix{T}; disc = false, her = false) where {T}
       LinearAlgebra.checksquare(A)
-      adj = isa(A,Adjoint) && isa(E,Adjoint)
+      adj = isa(A, Adjoint) && isa(E, Adjoint)
       schur_flag = adj ? isschur(A.parent, A.parent) : isschur(A, E)
-      return new{T}(adj ? A.parent : A, adj ? E.parent : E, disc, her, adj, schur_flag)
-  end
+      a = adj ? A.parent : A
+      e = adj ? E.parent : E
+      return new{T,typeof(a),typeof(e)}(a, e, disc, her, adj, schur_flag)
+   end
 end
+
 """
-    LINV = invlyapop(A, E; disc = false, her = false) 
+    LINV = invlyapop(A, E; disc = false, her = false)
 
 Define `LINV`, the inverse of the continuous Lyapunov operator `L:X -> AXE'+EXA'` for `disc = false`
 or the inverse of the discrete Lyapunov operator `L:X -> AXA'-EXE'` for `disc = true`, where
 `(A,E)` is a pair of `n x n` matrices.
 If `her = false` the inverse Lyapunov operator `LINV:Y -> X` maps general square matrices `Y`
-into general square matrices `X`, and the associated matrix `M = Matrix(LINV)` is 
+into general square matrices `X`, and the associated matrix `M = Matrix(LINV)` is
 ``n^2 \\times n^2``.
 If `her = true` the inverse Lyapunov operator `LINV:Y -> X` maps symmetric/Hermitian matrices `Y`
-into symmetric/Hermitian matrices `X`, and the associated matrix `M = Matrix(LINV)` is 
+into symmetric/Hermitian matrices `X`, and the associated matrix `M = Matrix(LINV)` is
 ``n(n+1)/2 \\times n(n+1)/2``.
 For the definitions of the Lyapunov operators see:
 
 M. Konstantinov, V. Mehrmann, P. Petkov. On properties of Sylvester and Lyapunov
 operators. Linear Algebra and its Applications 312:35–71, 2000.
 """
-function invlyapop(A::AbstractMatrix{T}, E::AbstractMatrix{T}; disc = false, her = false) where {T <: BlasFloat}
-    InverseGeneralizedLyapunovMap(A, E; disc = disc, her = her)
+function invlyapop(A::AbstractMatrix{T}, E::AbstractMatrix{T}; disc=false, her=false) where {T <: BlasFloat}
+   InverseGeneralizedLyapunovMap(A, E; disc=disc, her=her)
 end
-invlyapop(F::GeneralizedSchur{T,Matrix{T}}; kwargs...) where T = InverseGeneralizedLyapunovMap(F.S, F.T; kwargs...)
-function invlyapop(A::AbstractMatrix, E::AbstractMatrix; kwargs...) 
-    T = promote_type(eltype(A), eltype(E))
-    T <: BlasFloat || (T = promote_type(T, Float64) )
-    invlyapop(convert(Matrix{T},A), convert(Matrix{T},E); kwargs...)
+invlyapop(F::GeneralizedSchur; kwargs...) = InverseGeneralizedLyapunovMap(F.S, F.T; kwargs...)
+function invlyapop(A::AbstractMatrix{T1}, E::AbstractMatrix{T2}; kwargs...) where {T1,T2}
+   T = promote_type(T1, T2, Float64)
+   invlyapop(convert(AbstractMatrix{T}, A), convert(AbstractMatrix{T}, E); kwargs...)
 end
 function Base.size(L::InverseGeneralizedLyapunovMap)
-    n = size(L.A,1)
-    N = L.her ? Int(n*(n+1)/2) : n*n
-    return (N,N)
+   n = size(L.A, 1)
+   N = L.her ? Int(n * (n + 1) / 2) : n * n
+   return (N, N)
 end
-Base.size(L::Adjoint{<:Any, <: InverseGeneralizedLyapunovMap}) = size(L.parent)
-function LinearAlgebra.mul!(y::AbstractVector, L::InverseGeneralizedLyapunovMap{T}, x::AbstractVector) where T
-  n = size(L.A,1)
-  T1 = promote_type(T, eltype(x))
-  y = try
-    if L.sf
-       if L.her
-          T1 == eltype(x) ? Y = vec2triu(-x, her = true) : Y = vec2triu(-convert(Vector{T1},x), her = true)
-          L.disc ? lyapds!(L.A, L.E, Y; adj = L.adj) : lyapcs!(L.A, L.E, Y; adj = L.adj)
-          y .= triu2vec(Y)
-       else
-         T1 == eltype(x) ? Y = copy(reshape(x, n, n)) : Y = copy(reshape(convert(Vector{T1},x), n, n)) 
-         if L.disc
-            L.adj ? gsylvs!(L.A, L.A, -L.E, L.E, Y, adjAC = true) : gsylvs!(L.A, L.A, -L.E, L.E, Y, adjBD = true)
+function mul!(y::AbstractVector, L::InverseGeneralizedLyapunovMap{T}, x::AbstractVector) where T
+   n = size(L.A, 1)
+   T1 = promote_type(T, eltype(x))
+   try
+      if L.sf
+         if L.her
+            Y = vec2triu(T1 == eltype(x) ? -x : -convert(Vector{T1}, x), her=true)
+            L.disc ? lyapds!(L.A, L.E, Y; adj=L.adj) : lyapcs!(L.A, L.E, Y; adj=L.adj)
+            y .= triu2vec(Y)
          else
-            L.adj ? (gsylvs!(L.A,L.E,L.E,L.A,Y,adjAC = true,DBSchur = true)) : (gsylvs!(L.A,L.E,L.E,L.A,Y,adjBD = true,DBSchur = true))
+            Y = copy(reshape(T1 == eltype(x) ? x : convert(Vector{T1}, x), n, n))
+            if L.disc
+               L.adj ? gsylvs!(L.A, L.A, -L.E, L.E, Y, adjAC=true) : gsylvs!(L.A, L.A, -L.E, L.E, Y, adjBD=true)
+            else
+               L.adj ? (gsylvs!(L.A, L.E, L.E, L.A, Y, adjAC=true, DBSchur=true)) : (gsylvs!(L.A, L.E, L.E, L.A, Y, adjBD=true, DBSchur=true))
+            end
+            copyto!(y, Y)
          end
-         y .= Y[:]
-       end
-    else
-       if L.her
-          T1 == eltype(x) ? Y = vec2triu(-x, her = true) : Y = vec2triu(-convert(Vector{T1}, x), her = true) 
-          if L.disc
-             L.adj ? (y .= triu2vec(lyapd(L.A', L.E', Y))) : (y .= triu2vec(lyapd(L.A, L.E, Y)))
-          else
-             L.adj ? (y .= triu2vec(lyapc(L.A', L.E', Y))) : (y .= triu2vec(lyapc(L.A, L.E, Y)))
-          end
-       else
-          T1 == eltype(x) ? Y = reshape(-x, n, n) : Y = reshape(-convert(Vector{T1}, x), n, n)
-          if L.disc
-             # L.adj ? (y .= gsylv(-L.A',L.A,L.E',L.E,Y)[:]) : (y .= gsylv(-L.A,L.A',L.E,L.E',Y)[:])
-             L.adj ? (y .= lyapd(L.A', L.E', Y)[:]) : (y .= lyapd(L.A, L.E, Y)[:])
-          else
-             # L.adj ? (y .= gsylv(L.A',L.E,L.E',L.A,Y)[:]) : (y .= gsylv(L.A,L.E',L.E,L.A',Y)[:])
-             L.adj ? (y .= lyapc(L.A', L.E', Y)[:]) : (y .= lyapc(L.A, L.E, Y)[:])
-          end
-          return y
-       end
-    end
-  catch err
-    findfirst("SingularException",string(err)) === nothing &&
-    findfirst("LAPACKException",string(err)) === nothing ? rethrow() : throw("ME:SingularException: Singular operator")
-  end
-  return y
+      else
+         if L.her
+            Y = vec2triu(T1 == eltype(x) ? -x : -convert(Vector{T1}, x), her=true)
+            if L.disc
+               L.adj ? (y .= triu2vec(lyapd(L.A', L.E', Y))) : (y .= triu2vec(lyapd(L.A, L.E, Y)))
+            else
+               L.adj ? (y .= triu2vec(lyapc(L.A', L.E', Y))) : (y .= triu2vec(lyapc(L.A, L.E, Y)))
+            end
+         else
+            Y = reshape(T1 == eltype(x) ? -x : -convert(Vector{T1}, x), n, n)
+            if L.disc
+               # L.adj ? (y .= gsylv(-L.A',L.A,L.E',L.E,Y)[:]) : (y .= gsylv(-L.A,L.A',L.E,L.E',Y)[:])
+               copyto!(y, L.adj ? lyapd(L.A', L.E', Y) : lyapd(L.A, L.E, Y))
+            else
+               # L.adj ? (y .= gsylv(L.A',L.E,L.E',L.A,Y)[:]) : (y .= gsylv(L.A,L.E',L.E,L.A',Y)[:])
+               copyto!(y, L.adj ? lyapc(L.A', L.E', Y) : lyapc(L.A, L.E, Y))
+            end
+            return y
+         end
+      end
+   catch err
+      findfirst("SingularException", string(err)) === nothing &&
+      findfirst("LAPACKException", string(err)) === nothing ? rethrow() : throw("ME:SingularException: Singular operator")
+   end
+   return y
 end
-LinearAlgebra.adjoint(L::InverseGeneralizedLyapunovMap{T}) where T = invlyapop(L.adj ? L.A : L.A', L.adj ? L.E : L.E'; disc = L.disc, her = L.her)
-LinearAlgebra.transpose(L::InverseGeneralizedLyapunovMap{T}) where T = invlyapop(L.adj ? L.A : L.A', L.adj ? L.E : L.E'; disc = L.disc, her = L.her)
-LinearAlgebra.inv(L::GeneralizedLyapunovMap{T}) where T = invlyapop(L.A, L.E; disc = L.disc, her = L.her)
-LinearAlgebra.inv(L::InverseGeneralizedLyapunovMap{T}) where T = lyapop(L.A, L.E; disc = L.disc, her = L.her)
+LinearAlgebra.adjoint(L::InverseGeneralizedLyapunovMap) = invlyapop(L.adj ? L.A : L.A', L.adj ? L.E : L.E'; disc=L.disc, her=L.her)
+LinearAlgebra.transpose(L::InverseGeneralizedLyapunovMap) = invlyapop(L.adj ? L.A : L.A', L.adj ? L.E : L.E'; disc=L.disc, her=L.her)
+LinearAlgebra.inv(L::GeneralizedLyapunovMap) = invlyapop(L.A, L.E; disc=L.disc, her=L.her)
+LinearAlgebra.inv(L::InverseGeneralizedLyapunovMap) = lyapop(L.A, L.E; disc=L.disc, her=L.her)
 
-struct SylvesterMap{T} <: SylvesterMatrixEquationsMaps{T}
-   A::AbstractMatrix
-   B::AbstractMatrix
+struct SylvesterMap{T,TA<:AbstractMatrix,TB<:AbstractMatrix} <: SylvesterMatrixEquationsMaps{T}
+   A::TA
+   B::TB
    disc::Bool
-   function SylvesterMap(A::AbstractMatrix{T}, B::AbstractMatrix{T}; disc = false) where {T}
+   function SylvesterMap(A::AbstractMatrix{T}, B::AbstractMatrix{T}; disc=false) where {T}
       LinearAlgebra.checksquare(A, B)
-      return new{T}(A, B, disc)
+      return new{T,typeof(A),typeof(B)}(A, B, disc)
    end
 end
+
 """
-    M = sylvop(A, B; disc = false) 
+    M = sylvop(A, B; disc = false)
 
 Define the continuous Sylvester operator `M: X -> AX+XB` if `disc = false`
 or the discrete Sylvester operator `M: X -> AXB+X` if `disc = true`, where `A` and `B` are square matrices.
 """
-function sylvop(A::AbstractMatrix{T}, B::AbstractMatrix{T}; disc = false) where T
-    SylvesterMap(A, B; disc = disc)
+function sylvop(A::AbstractMatrix{T}, B::AbstractMatrix{T}; disc=false) where T
+   SylvesterMap(A, B; disc=disc)
 end
-sylvop(A::Schur{T,Matrix{T}}, B::Schur{T,Matrix{T}}; kwargs...) where T = SylvesterMap(A.T, B.T; kwargs...)
+sylvop(A::Schur{S}, B::Schur{S}; kwargs...) where S = SylvesterMap(A.T, B.T; kwargs...)
 function sylvop(A::Number, B::Number; kwargs...)
-   T = promote_type(eltype(A),eltype(B))
-   SylvesterMap(A*ones(T,1,1), B*ones(T,1,1); kwargs...)
+   A, B = promote(A, B)
+   SylvesterMap(fill(A, 1, 1), fill(B, 1, 1); kwargs...)
 end
 function sylvop(A::AbstractMatrix{T1}, B::AbstractMatrix{T2}; kwargs...) where {T1,T2}
-   T = promote_type(eltype(A),eltype(B)) 
-   SylvesterMap(convert(Matrix{T},A), convert(Matrix{T},B); kwargs...)
+   T = promote_type(eltype(A), eltype(B))
+   SylvesterMap(convert(AbstractMatrix{T}, A), convert(AbstractMatrix{T}, B); kwargs...)
 end
-function Base.size(L::SylvesterMap)
-   N = size(L.A,1)*size(L.B,1)
-   return (N,N)
-end
-Base.size(L::Adjoint{<:Any, <: SylvesterMap}) = size(L.parent)
-function LinearAlgebra.mul!(y::AbstractVector, L::SylvesterMap{T}, x::AbstractVector) where T
-   m = size(L.A,1)
-   n = size(L.B,1)
+Base.size(L::SylvesterMap) = (N = size(L.A, 1) * size(L.B, 1); return (N, N))
+function mul!(y::AbstractVector, L::SylvesterMap{T}, x::AbstractVector) where T
+   m = size(L.A, 1)
+   n = size(L.B, 1)
    T1 = promote_type(T, eltype(x))
-   T == T1 ? X = reshape(x, m, n) : X = reshape(convert(Vector{T1}, x), m, n)
-   Y = reshape(y, (m, n))  
+   X = reshape(T == T1 ? x : convert(Vector{T1}, x), (m, n))
+   Y = reshape(y, (m, n))
    if L.disc
       # Y = A * X * B + X
-      Y .= X
-      temp = similar(Y, (m, n))
-      mul!(temp, L.A, X) 
-      mul!(Y, temp, L.B, 1, 1) 
+      copyto!(y, x)
+      mul!(Y, L.A*X, L.B, 1, 1)
    else
       # Y = A * X + X * B
-      mul!(Y, L.A, X) 
-      mul!(Y, X, L.B, 1, 1) 
+      mul!(Y, L.A, X)
+      mul!(Y, X, L.B, 1, 1)
    end
    return y
-end 
-LinearAlgebra.adjoint(L::SylvesterMap{T}) where T = SylvesterMap(L.A', L.B'; disc = L.disc)
-LinearAlgebra.transpose(L::SylvesterMap{T}) where T = SylvesterMap(L.A', L.B'; disc = L.disc)
-struct InverseSylvesterMap{T} <: SylvesterMatrixEquationsMaps{T}
-   A::AbstractMatrix
-   B::AbstractMatrix
+end
+LinearAlgebra.adjoint(L::SylvesterMap)   = SylvesterMap(L.A', L.B'; disc=L.disc)
+LinearAlgebra.transpose(L::SylvesterMap) = SylvesterMap(L.A', L.B'; disc=L.disc)
+
+struct InverseSylvesterMap{T,TA<:AbstractMatrix,TB<:AbstractMatrix} <: SylvesterMatrixEquationsMaps{T}
+   A::TA
+   B::TB
    disc::Bool
    adjA::Bool
    adjB::Bool
    sf::Bool
-   function InverseSylvesterMap(A::AbstractMatrix{T}, B::AbstractMatrix{T}; disc = false) where {T}
+   function InverseSylvesterMap(A::AbstractMatrix{T}, B::AbstractMatrix{T}; disc=false) where {T}
       LinearAlgebra.checksquare(A, B)
-      adjA = isa(A,Adjoint)
-      adjB = isa(B,Adjoint)
-      schur_flag = (adjA ? isschur(A.parent) : isschur(A)) && (adjB ? isschur(B.parent) : isschur(B)) 
-      return new{T}(adjA ? A.parent : A, adjB ? B.parent : B, disc, adjA, adjB, schur_flag)
+      adjA = isa(A, Adjoint)
+      adjB = isa(B, Adjoint)
+      schur_flag = (adjA ? isschur(A.parent) : isschur(A)) && (adjB ? isschur(B.parent) : isschur(B))
+      a = adjA ? A.parent : A
+      b = adjB ? B.parent : B
+      return new{T,typeof(a),typeof(b)}(a, b, disc, adjA, adjB, schur_flag)
    end
 end
+
 """
-    MINV = invsylvop(A, B; disc = false) 
+    MINV = invsylvop(A, B; disc = false)
 
 Define `MINV`, the inverse of the continuous Sylvester operator  `M: X -> AX+XB` if `disc = false`
 or of the discrete Sylvester operator `M: X -> AXB+X` if `disc = true`, where `A` and `B` are square matrices.
 """
-function invsylvop(A::AbstractMatrix{T}, B::AbstractMatrix{T}; disc = false) where T
-    InverseSylvesterMap(A, B; disc = disc)
+function invsylvop(A::AbstractMatrix{T}, B::AbstractMatrix{T}; disc=false) where T
+   InverseSylvesterMap(A, B; disc=disc)
 end
-invsylvop(A::Schur{T,Matrix{T}}, B::Schur{T,Matrix{T}}; kwargs...) where T = InverseSylvesterMap(A.T, B.T; kwargs...)
+invsylvop(A::Schur{S}, B::Schur{S}; kwargs...) where S = InverseSylvesterMap(A.T, B.T; kwargs...)
 function invsylvop(A::Number, B::Number; kwargs...)
-   T = promote_type(eltype(A),eltype(B))
-   InverseSylvesterMap(A*ones(T,1,1), B*ones(T,1,1); kwargs...)
+   A, B = promote(A, B)
+   InverseSylvesterMap(fill(A, 1, 1), fill(B, 1, 1); kwargs...)
 end
 function invsylvop(A::AbstractMatrix{T1}, B::AbstractMatrix{T2}; kwargs...) where {T1,T2}
-   T = promote_type(eltype(A),eltype(B)) 
-   InverseSylvesterMap(convert(Matrix{T},A), convert(Matrix{T},B); kwargs...)
+   T = promote_type(eltype(A), eltype(B))
+   InverseSylvesterMap(convert(AbstractMatrix{T}, A), convert(AbstractMatrix{T}, B); kwargs...)
 end
-function Base.size(L::InverseSylvesterMap)
-   m = size(L.A,1)
-   N = size(L.A,1)*size(L.B,1)
-   return (N,N)
-end
-Base.size(L::Adjoint{<:Any, <: InverseSylvesterMap}) = size(L.parent)
-function LinearAlgebra.mul!(y::AbstractVector, L::InverseSylvesterMap{T}, x::AbstractVector) where T
-   m = size(L.A,1)
-   n = size(L.B,1)
+Base.size(L::InverseSylvesterMap) = (N = size(L.A, 1) * size(L.B, 1); return (N, N))
+function mul!(y::AbstractVector, L::InverseSylvesterMap{T}, x::AbstractVector) where T
+   m = size(L.A, 1)
+   n = size(L.B, 1)
    T1 = promote_type(T, eltype(x))
-   y = try
+   try
       if L.sf
-         eltype(x) == T1 ? Y = reshape(copy(x), m, n) : Y = reshape(convert(Vector{T1}, x), m, n)
+         Y = reshape(eltype(x) == T1 ? copy(x) : convert(Vector{T1}, x), m, n)
          if L.disc
-            sylvds!(L.A, L.B, Y, adjA = L.adjA, adjB = L.adjB)
+            sylvds!(L.A, L.B, Y, adjA=L.adjA, adjB=L.adjB)
          else
-            sylvcs!(L.A, L.B, Y, adjA = L.adjA, adjB = L.adjB)
+            sylvcs!(L.A, L.B, Y, adjA=L.adjA, adjB=L.adjB)
          end
-         y .= Y[:]
+         copyto!(y, Y)
       else
-         eltype(x) == T1 ? Y = reshape(x, m, n) : Y = reshape(convert(Vector{T1}, x), m, n)
+         Y = reshape(eltype(x) == T1 ? x : convert(Vector{T1}, x), m, n)
          if L.disc
-            y .= sylvd(L.adjA ? L.A' : L.A, L.adjB ? L.B' : L.B, Y)[:]
+            copyto!(y, sylvd(L.adjA ? L.A' : L.A, L.adjB ? L.B' : L.B, Y))
          else
-            y .= sylvc(L.adjA ? L.A' : L.A, L.adjB ? L.B' : L.B, Y)[:]
+            copyto!(y, sylvc(L.adjA ? L.A' : L.A, L.adjB ? L.B' : L.B, Y))
          end
       end
    catch err
-       findfirst("SingularException",string(err)) === nothing &&
-       findfirst("LAPACKException",string(err)) === nothing ? rethrow() : throw("ME:SingularException: Singular operator")
+      findfirst("SingularException", string(err)) === nothing &&
+      findfirst("LAPACKException", string(err)) === nothing ? rethrow() : throw("ME:SingularException: Singular operator")
    end
    return y
-end 
-LinearAlgebra.adjoint(L::InverseSylvesterMap{T}) where T = InverseSylvesterMap(L.adjA ? L.A : L.A', L.adjB ? L.B : L.B'; disc = L.disc)
-LinearAlgebra.transpose(L::InverseSylvesterMap{T}) where T = InverseSylvesterMap(L.adjA ? L.A : L.A', L.adjB ? L.B : L.B'; disc = L.disc)
-LinearAlgebra.inv(L::SylvesterMap{T}) where T = InverseSylvesterMap(L.A, L.B; disc = L.disc)
-LinearAlgebra.inv(L::InverseSylvesterMap{T}) where T = SylvesterMap(L.A, L.B; disc = L.disc)
-struct GeneralizedSylvesterMap{T} <: SylvesterMatrixEquationsMaps{T}
-   A::AbstractMatrix
-   B::AbstractMatrix
-   C::AbstractMatrix
-   D::AbstractMatrix
+end
+LinearAlgebra.adjoint(L::InverseSylvesterMap) = InverseSylvesterMap(L.adjA ? L.A : L.A', L.adjB ? L.B : L.B'; disc=L.disc)
+LinearAlgebra.transpose(L::InverseSylvesterMap) = InverseSylvesterMap(L.adjA ? L.A : L.A', L.adjB ? L.B : L.B'; disc=L.disc)
+LinearAlgebra.inv(L::SylvesterMap) = InverseSylvesterMap(L.A, L.B; disc=L.disc)
+LinearAlgebra.inv(L::InverseSylvesterMap) = SylvesterMap(L.A, L.B; disc=L.disc)
+
+struct GeneralizedSylvesterMap{T,TA<:AbstractMatrix,TB<:AbstractMatrix,TC<:AbstractMatrix,TD<:AbstractMatrix} <: SylvesterMatrixEquationsMaps{T}
+   A::TA
+   B::TB
+   C::TC
+   D::TD
    function GeneralizedSylvesterMap(A::AbstractMatrix{T}, B::AbstractMatrix{T}, C::AbstractMatrix{T}, D::AbstractMatrix{T}) where {T}
       m, n = LinearAlgebra.checksquare(A, B)
-      [m; n] == LinearAlgebra.checksquare(C,D) ||
-             throw(DimensionMismatch("A, B, C and D have incompatible dimensions"))
-      return new{T}(A, B, C, D)
+      [m, n] == LinearAlgebra.checksquare(C, D) ||
+               throw(DimensionMismatch("A, B, C and D have incompatible dimensions"))
+      return new{T,typeof(A),typeof(B),typeof(C),typeof(D)}(A, B, C, D)
    end
 end
+
 """
-    M = sylvop(A, B, C, D) 
+    M = sylvop(A, B, C, D)
 
 Define the generalized Sylvester operator `M: X -> AXB+CXD`, where `(A,C)` and `(B,D)` a pairs of square matrices.
 """
 function sylvop(A::AbstractMatrix{T}, B::AbstractMatrix{T}, C::AbstractMatrix{T}, D::AbstractMatrix{T}) where T
-    GeneralizedSylvesterMap(A, B, C, D)
+   GeneralizedSylvesterMap(A, B, C, D)
 end
 function sylvop(A::AbstractMatrix{T1}, B::AbstractMatrix{T2}, C::AbstractMatrix{T3}, D::AbstractMatrix{T4}) where {T1,T2,T3,T4}
-   T = promote_type(T1, T2, T3, T4) 
-   GeneralizedSylvesterMap(convert(Matrix{T},A), convert(Matrix{T},B), convert(Matrix{T},C), convert(Matrix{T},D))
+   T = promote_type(T1, T2, T3, T4)
+   GeneralizedSylvesterMap(convert.(AbstractMatrix{T}, (A, B, C, D))...)
 end
-function Base.size(L::GeneralizedSylvesterMap)
-   N = size(L.A,1)*size(L.B,1)
-   return (N,N)
-end
-Base.size(L::Adjoint{<:Any, <: GeneralizedSylvesterMap}) = size(L.parent)
-function LinearAlgebra.mul!(y::AbstractVector, L::GeneralizedSylvesterMap{T}, x::AbstractVector) where T
-   m = size(L.A,1)
-   n = size(L.B,1)
+Base.size(L::GeneralizedSylvesterMap) = (N = size(L.A, 1) * size(L.B, 1); return (N, N))
+function mul!(y::AbstractVector, L::GeneralizedSylvesterMap{T}, x::AbstractVector) where T
+   m = size(L.A, 1)
+   n = size(L.B, 1)
    T1 = promote_type(T, eltype(x))
-   eltype(x) == T1 ? X = reshape(x, m, n) : X = reshape(convert(Vector{T1}, x), m, n)
-   Y = reshape(y, (m, n))  
+   X = reshape(eltype(x) == T1 ? x : convert(Vector{T1}, x), (m, n))
+   Y = reshape(y, (m, n))
    # Y = A * X * B + C * X * D
    temp = similar(Y, (m, n))
-   mul!(temp, L.A, X) 
-   mul!(Y, temp, L.B, 1, 0) 
-   mul!(temp, L.C, X) 
-   mul!(Y, temp, L.D, 1, 1) 
+   mul!(temp, L.A, X)
+   mul!(Y, temp, L.B, 1, 0)
+   mul!(temp, L.C, X)
+   mul!(Y, temp, L.D, 1, 1)
    return y
-end 
-LinearAlgebra.adjoint(L::GeneralizedSylvesterMap{T}) where T = 
+end
+LinearAlgebra.adjoint(L::GeneralizedSylvesterMap{T}) where T =
    GeneralizedSylvesterMap(L.A', L.B', L.C', L.D')
-LinearAlgebra.transpose(L::GeneralizedSylvesterMap{T}) where T = 
+LinearAlgebra.transpose(L::GeneralizedSylvesterMap{T}) where T =
    GeneralizedSylvesterMap(L.A', L.B', L.C', L.D')
 
-
-struct InverseGeneralizedSylvesterMap{T} <: SylvesterMatrixEquationsMaps{T}
-   A::AbstractMatrix
-   B::AbstractMatrix
-   C::AbstractMatrix
-   D::AbstractMatrix
+struct InverseGeneralizedSylvesterMap{T,TA<:AbstractMatrix,TB<:AbstractMatrix,TC<:AbstractMatrix,TD<:AbstractMatrix} <: SylvesterMatrixEquationsMaps{T}
+   A::TA
+   B::TB
+   C::TC
+   D::TD
    adjAC::Bool
    adjBD::Bool
    sf::Bool
@@ -662,210 +641,215 @@ struct InverseGeneralizedSylvesterMap{T} <: SylvesterMatrixEquationsMaps{T}
    DBSchur::Bool
    function InverseGeneralizedSylvesterMap(A::AbstractMatrix{T}, B::AbstractMatrix{T}, C::AbstractMatrix{T}, D::AbstractMatrix{T}) where {T}
       m, n = LinearAlgebra.checksquare(A, B)
-      [m; n] == LinearAlgebra.checksquare(C,D) ||
-             throw(DimensionMismatch("A, B, C and D have incompatible dimensions"))
-      adjAC = isa(A,Adjoint) && isa(C,Adjoint) 
-      adjBD = isa(B,Adjoint) && isa(D,Adjoint) 
-      ACSchur = (adjAC ? isschur(A.parent,C.parent) : isschur(A,C))
-      BDSchur = (adjBD ? isschur(B.parent,D.parent) : isschur(B,D))
-      DBSchur = (adjBD ? isschur(D.parent,B.parent) : isschur(D,B))
-      schur_flag = ACSchur && (BDSchur || DBSchur) 
-      return new{T}(adjAC ? A.parent : A, adjBD ? B.parent : B, adjAC ? C.parent : C, adjBD ? D.parent : D, adjAC, adjBD, schur_flag, BDSchur, DBSchur)
+      [m, n] == LinearAlgebra.checksquare(C, D) ||
+               throw(DimensionMismatch("A, B, C and D have incompatible dimensions"))
+      adjAC = isa(A, Adjoint) && isa(C, Adjoint)
+      adjBD = isa(B, Adjoint) && isa(D, Adjoint)
+      ACSchur = (adjAC ? isschur(A.parent, C.parent) : isschur(A, C))
+      BDSchur = (adjBD ? isschur(B.parent, D.parent) : isschur(B, D))
+      DBSchur = (adjBD ? isschur(D.parent, B.parent) : isschur(D, B))
+      schur_flag = ACSchur && (BDSchur || DBSchur)
+      a = adjAC ? A.parent : A
+      b = adjBD ? B.parent : B
+      c = adjAC ? C.parent : C
+      d = adjBD ? D.parent : D
+      return new{T,typeof(a),typeof(b),typeof(c),typeof(d)}(a, b, c, d, adjAC, adjBD, schur_flag, BDSchur, DBSchur)
    end
 end
 
 """
-    MINV = invsylvop(A, B, C, D) 
+    MINV = invsylvop(A, B, C, D)
 
-Define `MINV`, the inverse of the generalized Sylvester operator `M: X -> AXB+CXD`, 
+Define `MINV`, the inverse of the generalized Sylvester operator `M: X -> AXB+CXD`,
 where (A,C) and (B,D) a pairs of square matrices.
 """
 function invsylvop(A::AbstractMatrix{T}, B::AbstractMatrix{T}, C::AbstractMatrix{T}, D::AbstractMatrix{T}) where T
    InverseGeneralizedSylvesterMap(A, B, C, D)
 end
 function invsylvop(A::AbstractMatrix{T1}, B::AbstractMatrix{T2}, C::AbstractMatrix{T3}, D::AbstractMatrix{T4}) where {T1,T2,T3,T4}
-   T = promote_type(T1, T2, T3, T4) 
-   InverseGeneralizedSylvesterMap(convert(Matrix{T},A), convert(Matrix{T},B), convert(Matrix{T},C), convert(Matrix{T},D))
+   T = promote_type(T1, T2, T3, T4)
+   InverseGeneralizedSylvesterMap(convert.(AbstractMatrix{T}, (A, B, C, D))...)
 end
-function Base.size(L::InverseGeneralizedSylvesterMap)
-   N = size(L.A,1)*size(L.B,1)
-   return (N,N)
-end
-Base.size(L::Adjoint{<:Any, <: InverseGeneralizedSylvesterMap}) = size(L.parent)
-function LinearAlgebra.mul!(y::AbstractVector, L::InverseGeneralizedSylvesterMap{T}, x::AbstractVector) where T
-   m = size(L.A,1)
-   n = size(L.B,1)
+Base.size(L::InverseGeneralizedSylvesterMap) = (N = size(L.A, 1) * size(L.B, 1); return (N, N))
+function mul!(y::AbstractVector, L::InverseGeneralizedSylvesterMap{T}, x::AbstractVector) where T
+   m = size(L.A, 1)
+   n = size(L.B, 1)
    T1 = promote_type(T, eltype(x))
-   y = try
+   try
       if L.sf
-         eltype(x) == T1 ? Y = reshape(copy(x), m, n) : Y = reshape(convert(Vector{T1}, x), m, n)
-         gsylvs!(L.A, L.B, L.C, L.D, Y, adjAC = L.adjAC, adjBD = L.adjBD, DBSchur = L.DBSchur && !L.BDSchur)
-         y .= Y[:]
+         Y = reshape(eltype(x) == T1 ? copy(x) : convert(Vector{T1}, x), m, n)
+         gsylvs!(L.A, L.B, L.C, L.D, Y, adjAC=L.adjAC, adjBD=L.adjBD, DBSchur=L.DBSchur && !L.BDSchur)
+         copyto!(y, Y)
       else
-         eltype(x) == T1 ? Y = reshape(x, m, n) : Y = reshape(convert(Vector{T1}, x), m, n)
-         y .= gsylv(L.adjAC ? L.A' : L.A, L.adjBD ? L.B' : L.B, 
-                    L.adjAC ? L.C' : L.C, L.adjBD ? L.D' : L.D, Y)[:]
+         X = reshape(eltype(x) == T1 ? x : convert(Vector{T1}, x), m, n)
+         copyto!(y, gsylv(L.adjAC ? L.A' : L.A, L.adjBD ? L.B' : L.B,
+                           L.adjAC ? L.C' : L.C, L.adjBD ? L.D' : L.D, X))
       end
    catch err
-       findfirst("SingularException",string(err)) === nothing &&
-       findfirst("LAPACKException",string(err)) === nothing ? rethrow() : throw("ME:SingularException: Singular operator")
+      findfirst("SingularException", string(err)) === nothing &&
+      findfirst("LAPACKException", string(err)) === nothing ? rethrow() : throw("ME:SingularException: Singular operator")
    end
    return y
-end 
-invsylvop(F::GeneralizedSchur{T,Matrix{T}}, G::GeneralizedSchur{T,Matrix{T}}) where T = invsylvop(F.S, G.S, F.T, G.T)
-LinearAlgebra.adjoint(L::InverseGeneralizedSylvesterMap{T}) where T = 
-      InverseGeneralizedSylvesterMap(L.adjAC ? L.A : L.A', L.adjBD ? L.B : L.B', 
-                                     L.adjAC ? L.C : L.C', L.adjBD ? L.D : L.D')
-LinearAlgebra.transpose(L::InverseGeneralizedSylvesterMap{T}) where T = 
-      InverseGeneralizedSylvesterMap(L.adjAC ? L.A : L.A', L.adjBD ? L.B : L.B', 
-                                     L.adjAC ? L.C : L.C', L.adjBD ? L.D : L.D')
-LinearAlgebra.inv(L::GeneralizedSylvesterMap{T}) where T = 
-      InverseGeneralizedSylvesterMap(L.A, L.B, L.C, L.D)
-LinearAlgebra.inv(L::InverseGeneralizedSylvesterMap{T}) where T = 
-      GeneralizedSylvesterMap(L.A, L.B, L.C, L.D)
+end
+invsylvop(F::GeneralizedSchur{U}, G::GeneralizedSchur{U}) where U = invsylvop(F.S, G.S, F.T, G.T)
+LinearAlgebra.adjoint(L::InverseGeneralizedSylvesterMap{T}) where T =
+   InverseGeneralizedSylvesterMap(L.adjAC ? L.A : L.A', L.adjBD ? L.B : L.B',
+                                    L.adjAC ? L.C : L.C', L.adjBD ? L.D : L.D')
+LinearAlgebra.transpose(L::InverseGeneralizedSylvesterMap{T}) where T =
+   InverseGeneralizedSylvesterMap(L.adjAC ? L.A : L.A', L.adjBD ? L.B : L.B',
+                                    L.adjAC ? L.C : L.C', L.adjBD ? L.D : L.D')
+LinearAlgebra.inv(L::GeneralizedSylvesterMap{T}) where T =
+   InverseGeneralizedSylvesterMap(L.A, L.B, L.C, L.D)
+LinearAlgebra.inv(L::InverseGeneralizedSylvesterMap{T}) where T =
+   GeneralizedSylvesterMap(L.A, L.B, L.C, L.D)
 
-struct SylvesterSystemMap{T} <: SylvesterMatrixEquationsMaps{T}
-   A::AbstractMatrix
-   B::AbstractMatrix
-   C::AbstractMatrix
-   D::AbstractMatrix
+struct SylvesterSystemMap{T,TA<:AbstractMatrix,TB<:AbstractMatrix,TC<:AbstractMatrix,TD<:AbstractMatrix} <: SylvesterMatrixEquationsMaps{T}
+   A::TA
+   B::TB
+   C::TC
+   D::TD
    function SylvesterSystemMap(A::AbstractMatrix{T}, B::AbstractMatrix{T}, C::AbstractMatrix{T}, D::AbstractMatrix{T}) where {T}
       m, n = LinearAlgebra.checksquare(A, B)
-      [m; n] == LinearAlgebra.checksquare(C,D) ||
-             throw(DimensionMismatch("A, B, C and D have incompatible dimensions"))
-      return new{T}(A, B, C, D)
+      [m, n] == LinearAlgebra.checksquare(C, D) ||
+         throw(DimensionMismatch("A, B, C and D have incompatible dimensions"))
+      return new{T,typeof(A),typeof(B),typeof(C),typeof(D)}(A, B, C, D)
    end
 end
-"""
-    M = sylvsysop(A, B, C, D) 
 
-Define the operator `M: (X,Y) -> (AX+YB, CX+YD )`, 
+"""
+    M = sylvsysop(A, B, C, D)
+
+Define the operator `M: (X,Y) -> (AX+YB, CX+YD )`,
 where `(A,C)` and `(B,D)` a pairs of square matrices.
 """
 function sylvsysop(A::AbstractMatrix{T}, B::AbstractMatrix{T}, C::AbstractMatrix{T}, D::AbstractMatrix{T}) where T
-    SylvesterSystemMap(A, B, C, D)
+   SylvesterSystemMap(A, B, C, D)
 end
 function sylvsysop(A::AbstractMatrix{T1}, B::AbstractMatrix{T2}, C::AbstractMatrix{T3}, D::AbstractMatrix{T4}) where {T1,T2,T3,T4}
-   T = promote_type(T1, T2, T3, T4) 
-   SylvesterSystemMap(convert(Matrix{T},A), convert(Matrix{T},B), convert(Matrix{T},C), convert(Matrix{T},D))
+   T = promote_type(T1, T2, T3, T4)
+   SylvesterSystemMap(convert.(AbstractMatrix{T}, (A, B, C, D))...)
 end
-function Base.size(L::SylvesterSystemMap)
-   N = size(L.A,1)*size(L.B,1)*2
-   return (N,N)
-end
-Base.size(L::Adjoint{<:Any, <: SylvesterSystemMap}) = size(L.parent)
-function LinearAlgebra.mul!(y::AbstractVector, L::SylvesterSystemMap{T}, x::AbstractVector) where T
-   m = size(L.A,1)
-   n = size(L.B,1)
-   mn = m*n
+Base.size(L::SylvesterSystemMap) = (N = size(L.A, 1) * size(L.B, 1) * 2; return (N, N))
+function mul!(y::AbstractVector, L::SylvesterSystemMap{T}, x::AbstractVector) where T
+   require_one_based_indexing(y, x)
+   m = size(L.A, 1)
+   n = size(L.B, 1)
+   mn = m * n
    T1 = promote_type(T, eltype(x))
-   eltype(x) == T1 ? X = reshape(view(x,1:mn), m, n) : X = reshape(convert(Vector{T1}, view(x,1:m*n)), m, n)
-   eltype(x) == T1 ? Y = reshape(view(x,mn+1:2*mn), m, n) : Y = reshape(convert(Vector{T1}, view(x,mn+1:2*mn)), m, n)
-   U = reshape(view(y,1:m*n), (m, n))  
-   V = reshape(view(y,mn+1:2*mn), (m, n))  
-   # U = A * X + Y * B 
+   X1 = reshape(eltype(x) == T1 ? view(x, 1:mn) : convert(Vector{T1}, view(x, 1:m * n)), m, n)
+   X2 = reshape(eltype(x) == T1 ? view(x, mn + 1:2 * mn) : convert(Vector{T1}, view(x, mn + 1:2 * mn)), m, n)
+   U = reshape(view(y, 1:m * n), (m, n))
+   V = reshape(view(y, mn + 1:2 * mn), (m, n))
+   # U = A * X + Y * B
    # V = C * X + Y * D
-   mul!(U, L.A, X) 
-   mul!(U, Y, L.B, 1, 1) 
-   mul!(V, L.C, X) 
-   mul!(V, Y, L.D, 1, 1) 
+   mul!(U, L.A, X1)
+   mul!(U, X2, L.B, 1, 1)
+   mul!(V, L.C, X1)
+   mul!(V, X2, L.D, 1, 1)
    return y
-end 
-function LinearAlgebra.mul!(y::AbstractVector, LT::Union{LinearMaps.TransposeMap{T, SylvesterSystemMap{T}},LinearMaps.AdjointMap{T, SylvesterSystemMap{T}}}, x::AbstractVector) where T
-   m = size(LT.lmap.A,1)
-   n = size(LT.lmap.B,1)
-   mn = m*n
-   T1 = promote_type(T, eltype(x))
-   eltype(x) == T1 ? X = reshape(view(x,1:mn), m, n) : X = reshape(convert(Vector{T1}, view(x,1:m*n)), m, n)
-   eltype(x) == T1 ? Y = reshape(view(x,mn+1:2*mn), m, n) : X = reshape(convert(Vector{T1}, view(x,mn+1:2*mn)), m, n)
-   U = reshape(view(y,1:m*n), (m, n))  
-   V = reshape(view(y,mn+1:2*mn), (m, n))  
-   # U = A' * X + C' * Y 
-   # V = X * B' + Y * D'
-   mul!(U, LT.lmap.A', X) 
-   mul!(U, LT.lmap.C', Y, 1, 1) 
-   mul!(V, X, LT.lmap.B') 
-   mul!(V, Y, LT.lmap.D', 1, 1) 
-   return y
-end 
-struct InverseSylvesterSystemMap{T} <: SylvesterMatrixEquationsMaps{T}
-   A::AbstractMatrix
-   B::AbstractMatrix
-   C::AbstractMatrix
-   D::AbstractMatrix
+end
+for ttype in (LinearMaps.TransposeMap, LinearMaps.AdjointMap)
+   @eval function mul!(y::AbstractVector, LT::$ttype{T,<:SylvesterSystemMap{T}}, x::AbstractVector) where T
+      require_one_based_indexing(y, x)
+      m = size(LT.lmap.A, 1)
+      n = size(LT.lmap.B, 1)
+      mn = m * n
+      T1 = promote_type(T, eltype(x))
+      X1 = reshape(eltype(x) == T1 ? view(x, 1:mn) : convert(Vector{T1}, view(x, 1:m * n)), m, n)
+      X2 = reshape(eltype(x) == T1 ? view(x, mn + 1:2 * mn) : convert(Vector{T1}, view(x, mn + 1:2 * mn)), m, n)
+      U = reshape(view(y, 1:m * n), (m, n))
+      V = reshape(view(y, mn + 1:2 * mn), (m, n))
+      # U = A' * X + C' * Y
+      # V = X * B' + Y * D'
+      mul!(U, LT.lmap.A', X1)
+      mul!(U, LT.lmap.C', X2, 1, 1)
+      mul!(V, X1, LT.lmap.B')
+      mul!(V, X2, LT.lmap.D', 1, 1)
+      return y
+   end
+end
+
+struct InverseSylvesterSystemMap{T,TA<:AbstractMatrix,TB<:AbstractMatrix,TC<:AbstractMatrix,TD<:AbstractMatrix} <: SylvesterMatrixEquationsMaps{T}
+   A::TA
+   B::TB
+   C::TC
+   D::TD
    sf::Bool
    function InverseSylvesterSystemMap(A::AbstractMatrix{T}, B::AbstractMatrix{T}, C::AbstractMatrix{T}, D::AbstractMatrix{T}) where {T}
       m, n = LinearAlgebra.checksquare(A, B)
-      [m; n] == LinearAlgebra.checksquare(C,D) ||
-             throw(DimensionMismatch("A, B, C and D have incompatible dimensions"))
-      schur_flag = isschur(A,C) && isschur(B,D)
-      return new{T}(A, B, C, D, schur_flag)
+      [m, n] == LinearAlgebra.checksquare(C, D) ||
+               throw(DimensionMismatch("A, B, C and D have incompatible dimensions"))
+      schur_flag = isschur(A, C) && isschur(B, D)
+      return new{T,typeof(A),typeof(B),typeof(C),typeof(D)}(A, B, C, D, schur_flag)
    end
 end
 """
-    MINV = invsylvsysop(A, B, C, D) 
+    MINV = invsylvsysop(A, B, C, D)
 
-Define `MINV`, the inverse of the linear operator `M: (X,Y) -> (AX+YB, CX+YD )`, 
+Define `MINV`, the inverse of the linear operator `M: (X,Y) -> (AX+YB, CX+YD )`,
 where `(A,C)` and `(B,D)` a pairs of square matrices.
 """
 function invsylvsysop(A::AbstractMatrix{T}, B::AbstractMatrix{T}, C::AbstractMatrix{T}, D::AbstractMatrix{T}) where T
-    InverseSylvesterSystemMap(A, B, C, D)
+   InverseSylvesterSystemMap(A, B, C, D)
 end
 function invsylvsysop(A::AbstractMatrix{T1}, B::AbstractMatrix{T2}, C::AbstractMatrix{T3}, D::AbstractMatrix{T4}) where {T1,T2,T3,T4}
-   T = promote_type(T1, T2, T3, T4) 
-   InverseSylvesterSystemMap(convert(Matrix{T},A), convert(Matrix{T},B), convert(Matrix{T},C), convert(Matrix{T},D))
+   T = promote_type(T1, T2, T3, T4)
+   InverseSylvesterSystemMap(convert.(AbstractMatrix{T}, (A, B, C, D))...)
 end
-function Base.size(L::InverseSylvesterSystemMap)
-   N = size(L.A,1)*size(L.B,1)*2
-   return (N,N)
-end
-Base.size(L::Adjoint{<:Any, <: InverseSylvesterSystemMap}) = size(L.parent)
-function LinearAlgebra.mul!(y::AbstractVector, L::InverseSylvesterSystemMap{T}, x::AbstractVector) where T
-   m = size(L.A,1)
-   n = size(L.B,1)
+Base.size(L::InverseSylvesterSystemMap) = (N = size(L.A, 1) * size(L.B, 1) * 2; return (N, N))
+function mul!(y::AbstractVector, L::InverseSylvesterSystemMap{T}, x::AbstractVector) where T
+   require_one_based_indexing(y, x)
+   m = size(L.A, 1)
+   n = size(L.B, 1)
    T1 = promote_type(T, eltype(x))
-   mn = m*n
-   eltype(x) == T1 ? E = reshape(x[1:mn], m, n) : E = reshape(convert(Vector{T1}, view(x,1:m*n)), m, n)
-   eltype(x) == T1 ? F = reshape(x[mn+1:2*mn], m, n) : F = reshape(convert(Vector{T1}, view(x,mn+1:2*mn)), m, n)
-   X = reshape(view(y,1:m*n), (m, n))  
-   Y = reshape(view(y,mn+1:2*mn), (m, n))  
-   y = try
+   mn = m * n
+   E = reshape(eltype(x) == T1 ? x[1:mn] : convert(Vector{T1}, view(x, 1:m * n)), m, n)
+   F = reshape(eltype(x) == T1 ? x[mn + 1:2 * mn] : convert(Vector{T1}, view(x, mn + 1:2 * mn)), m, n)
+   Y1 = view(y, 1:mn)
+   Y2 = view(y, mn + 1:2mn)
+   try
       if L.sf
-         X, Y = sylvsyss!(L.A,L.B,E,L.C,L.D,F) 
-         y .= [X Y][:]
+         X1, X2 = sylvsyss!(L.A, L.B, E, L.C, L.D, F)
+         copyto!(Y1, X1)
+         copyto!(Y2, X2)
       else
-         X, Y = sylvsys(L.A,L.B,E,L.C,L.D,F)
-         y .= [X Y][:]
+         X1, X2  = sylvsys(L.A, L.B, E, L.C, L.D, F)
+         copyto!(Y1, X1)
+         copyto!(Y2, X2)
       end
    catch err
-       findfirst("LAPACKException",string(err)) === nothing ? rethrow() : throw("ME:SingularException: Singular operator")
+      findfirst("LAPACKException", string(err)) === nothing ? rethrow() : throw("ME:SingularException: Singular operator")
    end
    return y
-end 
-function LinearAlgebra.mul!(y::AbstractVector, L::Union{LinearMaps.TransposeMap{T, InverseSylvesterSystemMap{T}},LinearMaps.AdjointMap{T, InverseSylvesterSystemMap{T}}}, x::AbstractVector) where T
-   m = size(L.lmap.A,1)
-   n = size(L.lmap.B,1)
-   mn = m*n
-   T1 = promote_type(T, eltype(x))
-   mn = m*n
-   eltype(x) == T1 ? E = reshape(x[1:mn], m, n) : E = reshape(convert(Vector{T1}, view(x,1:m*n)), m, n)
-   eltype(x) == T1 ? F = reshape(x[mn+1:2*mn], m, n) : F = reshape(convert(Vector{T1}, view(x,mn+1:2*mn)), m, n)
-   X = reshape(view(y,1:m*n), (m, n))  
-   Y = reshape(view(y,mn+1:2*mn), (m, n))  
-   y = try
-      if L.lmap.sf
-         X, Y = dsylvsyss!(L.lmap.A,L.lmap.B,E,L.lmap.C,L.lmap.D,F) 
-         y .= [X Y][:]
-      else
-         X, Y = dsylvsys(L.lmap.A',L.lmap.B',E,L.lmap.C',L.lmap.D',F)
-         y .= [X Y][:]
+end
+for ttype in (LinearMaps.TransposeMap, LinearMaps.AdjointMap)
+   @eval function mul!(y::AbstractVector, L::$ttype{T,<:InverseSylvesterSystemMap}, x::AbstractVector) where T
+      require_one_based_indexing(y, x)
+      m = size(L.lmap.A, 1)
+      n = size(L.lmap.B, 1)
+      mn = m * n
+      T1 = promote_type(T, eltype(x))
+      E = reshape(eltype(x) == T1 ? x[1:mn] : convert(Vector{T1}, view(x, 1:m * n)), m, n)
+      F = reshape(eltype(x) == T1 ? x[mn + 1:2 * mn] : convert(Vector{T1}, view(x, mn + 1:2 * mn)), m, n)
+      Y1 = view(y, 1:mn)
+      Y2 = view(y, mn + 1:2mn)
+      try
+         if L.lmap.sf
+            X1, X2 = dsylvsyss!(L.lmap.A, L.lmap.B, E, L.lmap.C, L.lmap.D, F)
+            copyto!(Y1, X1)
+            copyto!(Y2, X2)
+         else
+            X1, X2 = dsylvsys(L.lmap.A', L.lmap.B', E, L.lmap.C', L.lmap.D', F)
+            copyto!(Y1, X1)
+            copyto!(Y2, X2)
+         end
+      catch err
+         findfirst("LAPACKException", string(err)) === nothing ? rethrow() : throw("ME:SingularException: Singular operator")
       end
-   catch err
-       findfirst("LAPACKException",string(err)) === nothing ? rethrow() : throw("ME:SingularException: Singular operator")
+      return y
    end
-   return y
-end 
-invsylvsysop(AC :: GeneralizedSchur, BD :: GeneralizedSchur) = invsylvsysop(AC.S, BD.S, AC.T, BD.T)
-LinearAlgebra.inv(L::SylvesterSystemMap{T}) where T = InverseSylvesterSystemMap(L.A, L.B, L.C, L.D)
-LinearAlgebra.inv(L::InverseSylvesterSystemMap{T}) where T = SylvesterSystemMap(L.A, L.B, L.C, L.D)
+end
+invsylvsysop(AC::GeneralizedSchur{U}, BD::GeneralizedSchur{U}) where U = invsylvsysop(AC.S, BD.S, AC.T, BD.T)
+LinearAlgebra.inv(L::SylvesterSystemMap) = InverseSylvesterSystemMap(L.A, L.B, L.C, L.D)
+LinearAlgebra.inv(L::InverseSylvesterSystemMap) = SylvesterSystemMap(L.A, L.B, L.C, L.D)
 

--- a/src/meoperators.jl
+++ b/src/meoperators.jl
@@ -215,7 +215,7 @@ function mul!(y::AbstractVector, L::GeneralizedLyapunovMap{T}, x::AbstractVector
          mul!(Y, L.A, temp)
          mul!(temp, X, L.E')
          mul!(Y, L.E, temp, -1, 1)
-        return y
+         return y
       else
          # (y[:] = (L.A*X*L.E' + L.E*X*L.A')[:])
          mul!(temp, L.E, X)

--- a/src/meutil.jl
+++ b/src/meutil.jl
@@ -8,7 +8,7 @@ complex conjugate eigenvalues. In the complex case, it is tested if `A`
 is upper triangular.
 """
 function isschur(A)
-   @assert !Base.has_offset_axes(A)
+   require_one_based_indexing(A)
    m, n = size(A)
    m == n || (return false)
    m == 1 && (return true)
@@ -16,9 +16,9 @@ function isschur(A)
    m == 2 && (return true)
    if istriu(A,-1)
       for i = 1:m-2
-          if !iszero(A[i+1,i]) & !iszero(A[i+2,i+1])
-                return false
-          end
+         if !iszero(A[i+1,i]) & !iszero(A[i+2,i+1])
+            return false
+         end
       end
       return true
    else
@@ -58,6 +58,7 @@ function sfstruct(A)
    return resize!(ba,p), p
    #return ba[1:p], p
 end
+
 """
     utqu!(Q,U) -> Q
 
@@ -72,10 +73,10 @@ function utqu!(Q,U)
       throw(DimensionMismatch("U must be a matrix of dimension $n x $n"))
 
    T = promote_type(eltype(Q),eltype(U))
-   if !(T <: BlasFloat) 
+   if !(T <: BlasFloat)
       if T == eltype(Q)
          Q[:,:] = U'*Q*U
-         return 
+         return
       else
          error("TypeError: same type expected for Q and U ")
       end
@@ -85,7 +86,7 @@ function utqu!(Q,U)
    Qd = view(Q,diagind(Q))
    rmul!(Qd,one(T)/2)
    if isa(U,Adjoint)
-      mul!(Q, U.parent*UpperTriangular(Q), U) 
+      mul!(Q, U.parent*UpperTriangular(Q), U)
    else
       mul!(Q, Adjoint(U), UpperTriangular(Q)*U)
    end
@@ -127,7 +128,7 @@ function utqu(Q,U)
    t = UpperTriangular(Q)-Diagonal(Q[diagind(Q)]./2)
    X = similar(Q, T, m, m)
    if adj
-      mul!(X, U.parent*t, U) 
+      mul!(X, U.parent*t, U)
    else
       mul!(X, Adjoint(U), t*U)
    end
@@ -213,7 +214,7 @@ end
 """
     x = triu2vec(Q; rowwise = false, her = false)
 
-Reshape the upper triangular part of the `nxn` array `Q` as a one-dimensional column 
+Reshape the upper triangular part of the `nxn` array `Q` as a one-dimensional column
 vector `x` with `n(n+1)/2` elements. `Q` is assumed symmetric/hermitian if `her = true`.
 The elements of `x` correspond to stacking the elements of successive columns
 of the upper triangular part of `Q`, if `rowwise = false`, or stacking the elements
@@ -245,7 +246,7 @@ end
     Q = vec2triu(x; rowwise = false, her = false)
 
 Build from a one-dimensional column vector `x` with `n(n+1)/2` elements
-an `nxn` upper triangular matrix `Q` if `her = false` or an `nxn` symetric/hermitian 
+an `nxn` upper triangular matrix `Q` if `her = false` or an `nxn` symetric/hermitian
 array `Q` if `her = true`.
 The elements of `x` correspond to stacking the elements of successive columns
 of the upper triangular part of `Q`, if `rowwise = false`, or stacking the elements
@@ -255,7 +256,7 @@ function vec2triu(x::AbstractVector{T}; rowwise = false, her = false) where T
    k = length(x)
    n = (sqrt(1+8*k)-1)/2
    isinteger(n) ? n = Int(n) : error("The lenght of x must be of the form n(n+1)/2")
-   her ? Q = Array{T,2}(undef,n,n) : Q = zeros(T,n,n) 
+   her ? Q = Array{T,2}(undef,n,n) : Q = zeros(T,n,n)
    k = 1
    if rowwise
       for i = 1:n
@@ -285,7 +286,7 @@ function vec2triu(x::AbstractVector{T}; rowwise = false, her = false) where T
    end
    return Q
 end
-function utnormalize!(U::UpperTriangular{T},adj::Bool) where T 
+function utnormalize!(U::UpperTriangular{T},adj::Bool) where T
    # Normalize an upper traiangular matrix U such that its diagonal elements are non-negative
    # using diagonal orthogonal or unitary transformations.
    ZERO = zero(real(T))
@@ -298,11 +299,11 @@ function utnormalize!(U::UpperTriangular{T},adj::Bool) where T
             end
       else
          for i = 1:n
-             d = abs(U[i,i])
-             (!iszero(d) && !(iszero(imag(U[i,i])) && real(U[i,i]) > ZERO)) && 
-                  (tmp = conj(U[i,i])/d; rmul!(view(U,i,i:n),tmp))
-                  #(tmp = conj(U[i,i])/d; [@inbounds U[i,j] *= tmp for j = i:n])
-            end
+            d = abs(U[i,i])
+            (!iszero(d) && !(iszero(imag(U[i,i])) && real(U[i,i]) > ZERO)) && 
+               (tmp = conj(U[i,i])/d; rmul!(view(U,i,i:n),tmp))
+               #(tmp = conj(U[i,i])/d; [@inbounds U[i,j] *= tmp for j = i:n])
+         end
       end
    else
       # Make the diagonal elements of U non-negative.
@@ -312,11 +313,11 @@ function utnormalize!(U::UpperTriangular{T},adj::Bool) where T
          end
       else
          for j = 1:n
-             d = abs(U[j,j])
-             (!iszero(d) && (iszero(imag(U[j,j])) && real(U[j,j]) > ZERO)) && 
-                  (tmp = conj(U[j,j])/d; rmul!(view(U,1:j,j),tmp))
-                  #(tmp = conj(U[j,j])/d; [@inbounds U[i,j] *= tmp for i = 1:j])
-            end
+            d = abs(U[j,j])
+            (!iszero(d) && (iszero(imag(U[j,j])) && real(U[j,j]) > ZERO)) && 
+               (tmp = conj(U[j,j]) / d; rmul!(view(U, 1:j, j), tmp))
+               #(tmp = conj(U[j,j])/d; [@inbounds U[i,j] *= tmp for i = 1:j])
+         end
       end
    end
    return U
@@ -324,16 +325,16 @@ end
 @inline function luslv!(A::AbstractMatrix{T}, B::AbstractVector{T}) where T
    #
    #  fail = luslv!(A,B)
-   # 
+   #
    # This function is a speed-oriented implementation of a Gaussion-elimination based
-   # solver of small order linear equations of the form A*X = B. The computed solution X 
-   # overwrites the vector B, while the resulting A contains in its upper triangular part, 
-   # the upper triangular factor U of its LU decomposition. 
-   # The diagnostic output parameter fail, of type Bool, is set to false in the case 
-   # of normal return or is set to true if the exact singularity of A is detected 
+   # solver of small order linear equations of the form A*X = B. The computed solution X
+   # overwrites the vector B, while the resulting A contains in its upper triangular part,
+   # the upper triangular factor U of its LU decomposition.
+   # The diagnostic output parameter fail, of type Bool, is set to false in the case
+   # of normal return or is set to true if the exact singularity of A is detected
    # or if the resulting B has non-finite components.
    #
-   n = length(B) 
+   n = length(B)
    @inbounds begin
          for k = 1:n
             # find index max

--- a/src/plyapunov.jl
+++ b/src/plyapunov.jl
@@ -59,7 +59,7 @@ function plyapc(A::AbstractMatrix, B::AbstractMatrix)
 
    adj = isa(A,Adjoint)
    xor(adj,isa(B,Adjoint)) && error("Only calls with A and B or with A' and B' allowed")
- 
+
    n = LinearAlgebra.checksquare(A)
    if adj
       nb, mb = size(B)
@@ -120,7 +120,7 @@ function plyapc(A::AbstractMatrix, B::AbstractMatrix)
       U = UpperTriangular(LinearAlgebra.LAPACK.geqrf!(lmul!(U,copy(Q')),tau)[1])
    else
       #X <- Q*U*U'*Q'
-      U = UpperTriangular(LinearAlgebra.LAPACK.gerqf!(rmul!(Q,U),tau)[1])
+      U = UpperTriangular(LinearAlgebra.LAPACK.gerqf!(rmul!(Q, U), tau)[1])
    end  
    return utnormalize!(U,adj)
 end
@@ -217,7 +217,7 @@ function plyapc(A::AbstractMatrix, E::Union{AbstractMatrix,UniformScaling{Bool}}
    eltype(A) == T2 || (adj ? A = convert(Matrix{T2},A.parent)' : A = convert(Matrix{T2},A))
    eltype(E) == T2 || (adj ? E = convert(Matrix{T2},E.parent)' : E = convert(Matrix{T2},E))
    eltype(B) == T2 || (adj ? B = convert(Matrix{T2},B.parent)' : B = convert(Matrix{T2},B))
- 
+
    ZERO = zero(real(T2))
 
    # Reduce (A,E) to generalized Schur form and transform C
@@ -229,7 +229,7 @@ function plyapc(A::AbstractMatrix, E::Union{AbstractMatrix,UniformScaling{Bool}}
    end
 
    maximum(real(α./β)) >= ZERO && error("A-λE must have only eigenvalues with negative real parts")
- 
+
    if adj
       #U'*U = Z'*B'*B*Z
       tau = similar(Z,min(n,mb))
@@ -266,7 +266,7 @@ function plyapc(A::AbstractMatrix, E::Union{AbstractMatrix,UniformScaling{Bool}}
       U = UpperTriangular(LinearAlgebra.LAPACK.geqrf!(lmul!(U,copy(Q')),tau)[1])
    else
       #X <- Z*U*U'*Z'
-      U = UpperTriangular(LinearAlgebra.LAPACK.gerqf!(rmul!(Z,U),tau)[1])
+      U = UpperTriangular(LinearAlgebra.LAPACK.gerqf!(rmul!(Z, U), tau)[1])
    end  
    return utnormalize!(U,adj)
 end
@@ -337,7 +337,7 @@ function plyapd(A::AbstractMatrix, B::AbstractMatrix)
 
    adj = isa(A,Adjoint)
    xor(adj,isa(B,Adjoint)) && error("Only calls with A and B or with A' and B' allowed")
- 
+
    n = LinearAlgebra.checksquare(A)
    if adj
       nb, mb = size(B)
@@ -362,7 +362,7 @@ function plyapd(A::AbstractMatrix, B::AbstractMatrix)
       AS, Q, EV = schur(A)
    end
    maximum(abs.(EV)) >= ONE && error("A must have only eigenvalues with moduli less than one")
- 
+
    if adj
       #U'U = Q'*B'*B*Q
       tau = similar(Q,min(n,mb))
@@ -399,7 +399,7 @@ function plyapd(A::AbstractMatrix, B::AbstractMatrix)
       U = UpperTriangular(LinearAlgebra.LAPACK.geqrf!(lmul!(U,copy(Q')),tau)[1])
    else
       #X <- Q*U*U'*Q'
-      U = UpperTriangular(LinearAlgebra.LAPACK.gerqf!(rmul!(Q,U),tau)[1])
+      U = UpperTriangular(LinearAlgebra.LAPACK.gerqf!(rmul!(Q, U), tau)[1])
    end  
    return utnormalize!(U,adj)
 end
@@ -509,7 +509,7 @@ function plyapd(A::AbstractMatrix, E::Union{AbstractMatrix,UniformScaling{Bool}}
    end
 
    maximum(abs.(α./β)) >= ONE && error("A-λE must have only eigenvalues with moduli less than one")
- 
+
    if adj
       #U'*U = Z'*B'*B*Z
       tau = similar(Z,min(n,mb))
@@ -546,7 +546,7 @@ function plyapd(A::AbstractMatrix, E::Union{AbstractMatrix,UniformScaling{Bool}}
       U = UpperTriangular(LinearAlgebra.LAPACK.geqrf!(lmul!(U,copy(Q')),tau)[1])
    else
       #X <- Z*U*U'*Z'
-      U = UpperTriangular(LinearAlgebra.LAPACK.gerqf!(rmul!(Z,U),tau)[1])
+      U = UpperTriangular(LinearAlgebra.LAPACK.gerqf!(rmul!(Z, U), tau)[1])
    end  
    return utnormalize!(U,adj)
 end
@@ -621,7 +621,7 @@ function plyaps(A::AbstractMatrix, B::AbstractMatrix; disc = false)
 
    adj = isa(A,Adjoint)
    xor(adj,isa(B,Adjoint)) && error("Only calls with A and B or with A' and B' allowed")
- 
+
    n = LinearAlgebra.checksquare(A)
    if adj
       nb, mb = size(B)
@@ -742,7 +742,7 @@ function plyaps(A::AbstractMatrix, E::Union{AbstractMatrix,UniformScaling{Bool}}
    # [3] Penzl, T.
    #     Numerical solution of generalized Lyapunov equations.
    #     Advances in Comp. Math., vol. 8, pp. 33-48, 1998.
- 
+
    n = LinearAlgebra.checksquare(A)
    (typeof(E) == UniformScaling{Bool} || (isequal(E,I) &&  size(E,1) == n)) && (return plyaps(A, B))
    LinearAlgebra.checksquare(E) == n || throw(DimensionMismatch("E must be a $n x $n matrix or I"))
@@ -824,7 +824,7 @@ complex Schur form and `R` is an upper triangular matrix.
 function plyapcs!(A::Matrix{T1}, R::UpperTriangular{T1}; adj = false)  where T1 <: BlasReal
    n = LinearAlgebra.checksquare(A)
    LinearAlgebra.checksquare(R) == n || throw(DimensionMismatch("R must be a $n x $n upper triangular matrix"))
- 
+
    ONE = one(T1)
    ZERO = zero(T1)
    TWO = 2*ONE
@@ -889,7 +889,7 @@ function plyapcs!(A::Matrix{T1}, R::UpperTriangular{T1}; adj = false)  where T1 
              transpose!(view(R,l,j1),rmul!(z,-1))
              # update the Cholesky factor R1'*R1 <- R1'*R1 + y'*y
              # y = rbar - ubar * α'
-             mul!(rbar,z,transpose(α),-ONE,ONE)
+             mul!(rbar, z, transpose(α), -ONE, ONE)
              #rbar += ubar * α'
              qrupdate!(view(R,j1,j1), rbar)
          end
@@ -1071,7 +1071,7 @@ function plyapcs!(A::Matrix{T1}, E::Union{Matrix{T1},UniformScaling{Bool}},R::Up
    (typeof(E) == UniformScaling{Bool} || (isequal(E,I) && size(E,1) == n)) && (plyapcs!(A, R, adj = adj); return)
    LinearAlgebra.checksquare(E) == n || throw(DimensionMismatch("E must be a $n x $n matrix or I"))
    LinearAlgebra.checksquare(R) == n || throw(DimensionMismatch("R must be a $n x $n upper triangular matrix"))
-   
+
    ONE = one(T1)
    ZERO = zero(T1)
    TWO = 2*ONE
@@ -1239,7 +1239,7 @@ end
 function plyapcs!(A::Matrix{T1}, E::Union{Matrix{T1},UniformScaling{Bool}},R::UpperTriangular{T1}; adj = false)  where T1 <: BlasComplex
    n = LinearAlgebra.checksquare(A)
    LinearAlgebra.checksquare(R) == n || throw(DimensionMismatch("R must be a $n x $n upper triangular matrix"))
-   (typeof(E) == UniformScaling{Bool} || isempty(E) || (isequal(E,I) && size(E,1) == n)) && 
+   (typeof(E) == UniformScaling{Bool} || isempty(E) || (isequal(E,I) && size(E,1) == n)) &&
          (plyapcs!(A, R, adj = adj); return)
 
    LinearAlgebra.checksquare(E) == n || throw(DimensionMismatch("E must be a $n x $n matrix or I"))
@@ -2035,7 +2035,7 @@ must have moduli less than one. These conditions are checked and
 an error message is issued if not fulfilled.
 
 If the Lyapunov equation is numerically singular, then small perturbations in `A` can make
-one or more of the eigenvalues have a non-negative real part, if `disc = false`, or 
+one or more of the eigenvalues have a non-negative real part, if `disc = false`, or
 can make one or more of the eigenvalues lie outside the unit circle, if `disc = true`.
 If this situation is detected, an error message is issued.
 """
@@ -2192,7 +2192,7 @@ function plyap2!(A::AbstractMatrix{T}, R::AbstractMatrix{T}; adj = false, disc =
    end
 
    V3     = hypot3(P3,YR,YI)
-   ALPHA < ONE  &&  V3 > ONE && V3 > BIGNUM*ALPHA && error("$errtext") 
+   ALPHA < ONE  &&  V3 > ONE && V3 > BIGNUM*ALPHA && error("$errtext")
    V3 = V3/ALPHA
 
    if noadj
@@ -2393,8 +2393,8 @@ real parts, while, in the discrete-time case, the eigenvalues must have
 moduli less than unity. These conditions are checked and
 an error message is issued if not fulfilled.
 
-If the Lyapunov equation is numerically singular, then small perturbations in `A` or `E` 
-can make one or more of the eigenvalues have a non-negative real part, if `disc = false`, or 
+If the Lyapunov equation is numerically singular, then small perturbations in `A` or `E`
+can make one or more of the eigenvalues have a non-negative real part, if `disc = false`, or
 can make one or more of the eigenvalues lie outside the unit circle, if `disc = true`.
 If this situation is detected, an error message is issued.
 """
@@ -2412,7 +2412,7 @@ function pglyap2!(A::AbstractMatrix{T1}, E::AbstractMatrix{T1}, R::AbstractMatri
    #     Advances in Comp. Math., vol. 8, pp. 33-48, 1998.
 
    errtext = "Singular Lyapunov equation"
- 
+
    ZERO = zero(T1)
    ONE = one(T1)
    TWO = 2*ONE

--- a/src/sylvester.jl
+++ b/src/sylvester.jl
@@ -63,13 +63,13 @@ function sylvc(A::AbstractMatrix,B::AbstractMatrix,C::AbstractMatrix)
 
    m, n = size(C);
    [m; n] == LinearAlgebra.checksquare(A,B) || throw(DimensionMismatch("A, B and C have incompatible dimensions"))
- 
+
    T2 = promote_type(eltype(A), eltype(B), eltype(C))
    T2 <: BlasFloat || (T2 = promote_type(Float64,T2))
    eltype(A) == T2 || (A = convert(Matrix{T2},A))
    eltype(B) == T2 || (B = convert(Matrix{T2},B))
    eltype(C) == T2 || (C = convert(Matrix{T2},C))
- 
+
    adjA = isa(A,Adjoint)
    adjB = isa(B,Adjoint)
    if adjA
@@ -144,7 +144,7 @@ julia> C = [-1. -2.; 2. -1.]
 2×2 Array{Float64,2}:
  -1.0  -2.0
   2.0  -1.0
-   
+
 julia> X = sylvd(A, B, C)
 2×2 Array{Float64,2}:
  -2.46667  -2.73333
@@ -260,7 +260,7 @@ julia> X = gsylv(A, B, C, D, E)
 2×2 Array{Float64,2}:
  -0.52094   -0.0275792
  -0.168539   0.314607
- 
+
 julia> A*X*B + C*X*D - E
 2×2 Array{Float64,2}:
  4.44089e-16  8.88178e-16
@@ -412,7 +412,7 @@ function sylvsys(A::AbstractMatrix,B::AbstractMatrix,C::AbstractMatrix,D::Abstra
     isa(B,Adjoint) && (B = copy(B))
     isa(D,Adjoint) && (D = copy(D))
     isa(E,Adjoint) && (E = copy(E))
-    
+
     AS, DS, Q1, Z1 = schur(A,D)
     BS, ES, Q2, Z2 = schur(B,E)
 
@@ -482,7 +482,7 @@ julia> A*X + D*Y - C
 2×2 Array{Float64,2}:
   4.44089e-16  0.0
  -3.55271e-15  1.55431e-15
- 
+
 julia> X*B + Y*E - F
 2×2 Array{Float64,2}:
  -8.88178e-16   0.0
@@ -551,11 +551,11 @@ function sylvcs!(A::AbstractMatrix{T1}, B::AbstractMatrix{T1}, C::AbstractMatrix
       rmul!(C, inv(scale))
       return C[:,:]
    catch err
-      findfirst("LAPACKException(1)",string(err)) === nothing ? rethrow() : 
+      findfirst("LAPACKException(1)",string(err)) === nothing ? rethrow() :
                throw("ME:SingularException: A has eigenvalue(s) α and B has eigenvalues(s) β such that α+β = 0")
    end
 end
-function sylvd2!(adjA::Bool,adjB::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::AbstractMatrix{T},B::AbstractMatrix{T},Xw::AbstractMatrix{T}) where T <:BlasReal
+function sylvd2!(adjA::Bool, adjB::Bool, C::AbstractMatrix{T}, na::Int, nb::Int, A::AbstractMatrix{T}, B::AbstractMatrix{T}, Xw::AbstractMatrix{T}) where {T <:BlasReal}
    # speed and reduced allocation oriented implementation of a solver for 1x1 and 2x2 Sylvester equations 
    # encountered in solving discrete Lyapunov equations: 
    # A*X*B + X = C   if adjA = false and adjB = false -> R = kron(B',A) + I 
@@ -575,7 +575,7 @@ function sylvd2!(adjA::Bool,adjB::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::A
    Y = reshape(C, n)
    if adjA && !adjB
       if na == 1
-         # R12 = 
+         # R12 =
          # [ a11*b11+1      a11*b21]
          # [     a11*b12  a11*b22+1]
          # @inbounds R = [ A[1,1]*B[1,1]+ONE      A[1,1]*B[2,1];
@@ -588,7 +588,7 @@ function sylvd2!(adjA::Bool,adjB::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::A
          # @inbounds  Y[2] = C[1,2]
       else
          if nb == 1
-            # R21 = 
+            # R21 =
             # [ a11*b11+1      a21*b11]
             # [     a12*b11  a22*b11+1]
             # @inbounds R = [ A[1,1]*B[1,1]+ONE      A[2,1]*B[1,1];
@@ -600,7 +600,7 @@ function sylvd2!(adjA::Bool,adjB::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::A
             # @inbounds  Y[1] = C[1,1]
             # @inbounds  Y[2] = C[2,1]
          else
-            # R = 
+            # R =
             # [ a11*b11+1      a21*b11      a11*b21      a21*b21]
             # [     a12*b11  a22*b11+1      a12*b21      a22*b21]
             # [     a11*b12      a21*b12  a11*b22+1      a21*b22]
@@ -659,7 +659,7 @@ function sylvd2!(adjA::Bool,adjB::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::A
             # @inbounds  Y[1] = C[1,1]
             # @inbounds  Y[2] = C[2,1]
          else
-            # R = 
+            # R =
             # [ a11*b11+1      a12*b11      a11*b12      a12*b12]
             # [     a21*b11  a22*b11+1      a21*b12      a22*b12]
             # [     a11*b21      a12*b21  a11*b22+1      a12*b22]
@@ -693,7 +693,7 @@ function sylvd2!(adjA::Bool,adjB::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::A
       #R = kron(transpose(B),transpose(A)) + I
    elseif !adjA && !adjB
       if na == 1
-         # R12 = 
+         # R12 =
          # [ a11*b11 + 1,     a11*b21]
          # [     a11*b12, a11*b22 + 1]
          # @inbounds R = [ A[1,1]*B[1,1]+ONE      A[1,1]*B[2,1];
@@ -706,7 +706,7 @@ function sylvd2!(adjA::Bool,adjB::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::A
          # @inbounds  Y[2] = C[1,2]
       else
          if nb == 1
-            # R21 = 
+            # R21 =
             # [ a11*b11 + 1,     a12*b11]
             # [     a21*b11, a22*b11 + 1]
             # @inbounds R = [ A[1,1]*B[1,1]+ONE      A[1,2]*B[1,1];
@@ -718,7 +718,7 @@ function sylvd2!(adjA::Bool,adjB::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::A
             # @inbounds  Y[1] = C[1,1]
             # @inbounds  Y[2] = C[2,1]
          else
-            # R = 
+            # R =
             # [ a11*b11 + 1,     a12*b11,     a11*b21,     a12*b21]
             # [     a21*b11, a22*b11 + 1,     a21*b21,     a22*b21]
             # [     a11*b12,     a12*b12, a11*b22 + 1,     a12*b22]
@@ -752,7 +752,7 @@ function sylvd2!(adjA::Bool,adjB::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::A
       #R = kron(B,A) + I
    else
       if na == 1
-         # R12 = 
+         # R12 =
          # [ a11*b11 + 1,     a11*b12]
          # [     a11*b21, a11*b22 + 1]
          # @inbounds R = [ A[1,1]*B[1,1]+ONE      A[1,1]*B[1,2];
@@ -765,7 +765,7 @@ function sylvd2!(adjA::Bool,adjB::Bool,C::AbstractMatrix{T},na::Int,nb::Int,A::A
          # @inbounds  Y[2] = C[1,2]
       else
          if nb == 1
-            # R21 = 
+            # R21 =
             # [ a11*b11 + 1,     a21*b11]
             # [     a12*b11, a22*b11 + 1]
             # @inbounds R = [ A[1,1]*B[1,1]+ONE      A[2,1]*B[1,1];
@@ -838,7 +838,7 @@ function sylvds!(A::AbstractMatrix{T1}, B::AbstractMatrix{T1}, C::AbstractMatrix
    (size(C,1) == m && size(C,2) == n ) || throw(DimensionMismatch("C must be an $m x $n matrix"))
    (m, 2) == size(W) || throw(DimensionMismatch("W must be an $m x 2 matrix"))
    ONE = one(T1)
-  
+
    # determine the structure of the real Schur form of A
    ba, pa = sfstruct(A)
    bb, pb = sfstruct(B)
@@ -1253,7 +1253,7 @@ function gsylvs!(A::AbstractMatrix{T1}, B::AbstractMatrix{T1}, C::AbstractMatrix
        Comm. ACM, 15:820–826, 1972.
    """
    m, n = size(E);
-   [m; n; m; n] == LinearAlgebra.checksquare(A,B,C,D) || 
+   [m; n; m; n] == LinearAlgebra.checksquare(A,B,C,D) ||
       throw(DimensionMismatch("A, B, C, D and E have incompatible dimensions"))
 
    (m, 2) == size(WB) || throw(DimensionMismatch("WB must be an $m x 2 matrix"))
@@ -1263,7 +1263,7 @@ function gsylvs!(A::AbstractMatrix{T1}, B::AbstractMatrix{T1}, C::AbstractMatrix
 
    # determine the structure of the generalized real Schur form of (A,C)
    CASchur ? ((ba, pa) = sfstruct(C)) : ((ba, pa) = sfstruct(A))
-   DBSchur ? ((bb, pb) = sfstruct(D)) : ((bb, pb) = sfstruct(B)) 
+   DBSchur ? ((bb, pb) = sfstruct(D)) : ((bb, pb) = sfstruct(B))
 
    # WB = zeros(T1,m,2)
    # WD = zeros(T1,m,2)
@@ -1529,7 +1529,7 @@ end
    #      A*X*B' + C*X*D' = E   if adjAC = false and adjBD = true  -> R = kron(B,A)   + kron(D,C)
    #      A'*X*B' + C'*X*D' = E if adjAC = true and adjBD = true   -> R = kron(B,A')  + kron(D,C')
    if na == 1 && nb == 1
-      temp = A[1,1]*B[1,1] + C[1,1]*D[1,1] 
+      temp = A[1,1]*B[1,1] + C[1,1]*D[1,1]
       rmul!(E,inv(temp))
       any(!isfinite, E) &&  throw("ME:SingularException: `A-λC` and `D+λB` have common eigenvalues")
       return E
@@ -1540,7 +1540,7 @@ end
    Y = reshape(E, n)
    if !adjAC && !adjBD
       if na == 1
-         # R12 = 
+         # R12 =
          # [ a11*b11 + c11*d11, a11*b21 + c11*d21]
          # [ a11*b12 + c11*d12, a11*b22 + c11*d22]
          # @inbounds R = [ A[1,1]*B[1,1]+C[1,1]*D[1,1]      A[1,1]*B[2,1]+C[1,1]*D[2,1];
@@ -1553,7 +1553,7 @@ end
          # @inbounds  Y[2] = E[1,2]
       else
          if nb == 1
-            # R21 = 
+            # R21 =
             # [ a11*b11 + c11*d11, a12*b11 + c12*d11]
             # [ a21*b11 + c21*d11, a22*b11 + c22*d11]
             # @inbounds R = [ A[1,1]*B[1,1]+C[1,1]*D[1,1]      A[1,2]*B[1,1]+C[1,2]*D[1,1];
@@ -1565,7 +1565,7 @@ end
             # @inbounds  Y[1] = E[1,1]
             # @inbounds  Y[2] = E[2,1]
          else
-            # R = 
+            # R =
             # [ a11*b11 + c11*d11, a12*b11 + c12*d11, a11*b21 + c11*d21, a12*b21 + c12*d21]
             # [ a21*b11 + c21*d11, a22*b11 + c22*d11, a21*b21 + c21*d21, a22*b21 + c22*d21]
             # [ a11*b12 + c11*d12, a12*b12 + c12*d12, a11*b22 + c11*d22, a12*b22 + c12*d22]
@@ -1589,7 +1589,7 @@ end
             @inbounds  R[2,4] = A[2,2]*B[2,1]+C[2,2]*D[2,1]
             @inbounds  R[3,1] = A[1,1]*B[1,2]+C[1,1]*D[1,2]
             @inbounds  R[3,2] = A[1,2]*B[1,2]+C[1,2]*D[1,2]
-            @inbounds  R[3,3] = A[1,1]*B[2,2]+C[1,1]*D[2,2] 
+            @inbounds  R[3,3] = A[1,1]*B[2,2]+C[1,1]*D[2,2]
             @inbounds  R[3,4] = A[1,2]*B[2,2]+C[1,2]*D[2,2]
             @inbounds  R[4,1] = A[2,1]*B[1,2]+C[2,1]*D[1,2]
             @inbounds  R[4,2] = A[2,2]*B[1,2]+C[2,2]*D[1,2]
@@ -1604,7 +1604,7 @@ end
       #R = kron(transpose(B),A) + kron(transpose(D),C)
    elseif adjAC && !adjBD
       if na == 1
-         # R12 = 
+         # R12 =
          # [ a11*b11 + c11*d11, a11*b21 + c11*d21]
          # [ a11*b12 + c11*d12, a11*b22 + c11*d22]
          # @inbounds R = [ A[1,1]*B[1,1]+C[1,1]*D[1,1]      A[1,1]*B[2,1]+C[1,1]*D[2,1];
@@ -1617,7 +1617,7 @@ end
          # @inbounds  Y[2] = E[1,2]
       else
          if nb == 1
-            # R21 = 
+            # R21 =
             # [ a11*b11 + c11*d11, a21*b11 + c21*d11]
             # [ a12*b11 + c12*d11, a22*b11 + c22*d11]
             # @inbounds R = [ A[1,1]*B[1,1]+C[1,1]*D[1,1]      A[2,1]*B[1,1]+C[2,1]*D[1,1];
@@ -1629,7 +1629,7 @@ end
             # @inbounds  Y[1] = E[1,1]
             # @inbounds  Y[2] = E[2,1]
          else
-            # R = 
+            # R =
             # [ a11*b11 + c11*d11, a21*b11 + c21*d11, a11*b21 + c11*d21, a21*b21 + c21*d21]
             # [ a12*b11 + c12*d11, a22*b11 + c22*d11, a12*b21 + c12*d21, a22*b21 + c22*d21]
             # [ a11*b12 + c11*d12, a21*b12 + c21*d12, a11*b22 + c11*d22, a21*b22 + c21*d22]
@@ -1642,7 +1642,7 @@ end
             # (@inbounds R = [ A[1,1]*B[1,1]+C[1,1]*D[1,1]      A[2,1]*B[1,1]+C[2,1]*D[1,1]      A[1,1]*B[2,1]+C[1,1]*D[2,1]      A[2,1]*B[2,1]+C[2,1]*D[2,1];
             # A[1,2]*B[1,1]+C[1,2]*D[1,1]  A[2,2]*B[1,1]+C[2,2]*D[1,1]      A[1,2]*B[2,1]+C[1,2]*D[2,1]      A[2,2]*B[2,1]+C[2,2]*D[2,1];
             # A[1,1]*B[1,2]+C[1,1]*D[1,2]      A[2,1]*B[1,2]+C[2,1]*D[1,2]  A[1,1]*B[2,2]+C[1,1]*D[2,2]      A[2,1]*B[2,2]+C[2,1]*D[2,2];
-            # A[1,2]*B[1,2]+C[1,2]*D[1,2]      A[2,2]*B[1,2]+C[2,2]*D[1,2]      A[1,2]*B[2,2]+C[1,2]*D[2,2]  A[2,2]*B[2,2]+C[2,2]*D[2,2]]) 
+            # A[1,2]*B[1,2]+C[1,2]*D[1,2]      A[2,2]*B[1,2]+C[2,2]*D[1,2]      A[1,2]*B[2,2]+C[1,2]*D[2,2]  A[2,2]*B[2,2]+C[2,2]*D[2,2]])
             @inbounds  R[1,1] = A[1,1]*B[1,1]+C[1,1]*D[1,1]
             @inbounds  R[1,2] = A[2,1]*B[1,1]+C[2,1]*D[1,1]
             @inbounds  R[1,3] = A[1,1]*B[2,1]+C[1,1]*D[2,1]
@@ -1653,7 +1653,7 @@ end
             @inbounds  R[2,4] = A[2,2]*B[2,1]+C[2,2]*D[2,1]
             @inbounds  R[3,1] = A[1,1]*B[1,2]+C[1,1]*D[1,2]
             @inbounds  R[3,2] = A[2,1]*B[1,2]+C[2,1]*D[1,2]
-            @inbounds  R[3,3] = A[1,1]*B[2,2]+C[1,1]*D[2,2] 
+            @inbounds  R[3,3] = A[1,1]*B[2,2]+C[1,1]*D[2,2]
             @inbounds  R[3,4] = A[2,1]*B[2,2]+C[2,1]*D[2,2]
             @inbounds  R[4,1] = A[1,2]*B[1,2]+C[1,2]*D[1,2]
             @inbounds  R[4,2] = A[2,2]*B[1,2]+C[2,2]*D[1,2]
@@ -1668,7 +1668,7 @@ end
       #R = kron(transpose(B),transpose(A)) + kron(transpose(D),transpose(C))
    elseif !adjAC && adjBD
       if na == 1
-         # R12 = 
+         # R12 =
          # [ a11*b11 + c11*d11, a11*b12 + c11*d12]
          # [ a11*b21 + c11*d21, a11*b22 + c11*d22]
          # @inbounds R = [ A[1,1]*B[1,1]+C[1,1]*D[1,1]      A[1,1]*B[1,2]+C[1,1]*D[1,2];
@@ -1681,7 +1681,7 @@ end
          # @inbounds  Y[2] = E[1,2]
       else
          if nb == 1
-            # R21 = 
+            # R21 =
             # [ a11*b11 + c11*d11, a12*b11 + c12*d11]
             # [ a21*b11 + c21*d11, a22*b11 + c22*d11]
             # @inbounds R = [ A[1,1]*B[1,1]+C[1,1]*D[1,1]      A[1,2]*B[1,1]+C[1,2]*D[1,1];
@@ -1693,7 +1693,7 @@ end
             # @inbounds  Y[1] = E[1,1]
             # @inbounds  Y[2] = E[2,1]
          else
-            # R = 
+            # R =
             # [ a11*b11 + c11*d11, a12*b11 + c12*d11, a11*b12 + c11*d12, a12*b12 + c12*d12]
             # [ a21*b11 + c21*d11, a22*b11 + c22*d11, a21*b12 + c21*d12, a22*b12 + c22*d12]
             # [ a11*b21 + c11*d21, a12*b21 + c12*d21, a11*b22 + c11*d22, a12*b22 + c12*d22]
@@ -1706,7 +1706,7 @@ end
             # (@inbounds R = [ A[1,1]*B[1,1]+C[1,1]*D[1,1]      A[1,2]*B[1,1]+C[1,2]*D[1,1]      A[1,1]*B[1,2]+C[1,1]*D[1,2]      A[1,2]*B[1,2]+C[1,2]*D[1,2];
             # A[2,1]*B[1,1]+C[2,1]*D[1,1]  A[2,2]*B[1,1]+C[2,2]*D[1,1]      A[2,1]*B[1,2]+C[2,1]*D[1,2]      A[2,2]*B[1,2]+C[2,2]*D[1,2];
             # A[1,1]*B[2,1]+C[1,1]*D[2,1]      A[1,2]*B[2,1]+C[1,2]*D[2,1]  A[1,1]*B[2,2]+C[1,1]*D[2,2]      A[1,2]*B[2,2]+C[1,2]*D[2,2];
-            # A[2,1]*B[2,1]+C[2,1]*D[2,1]      A[2,2]*B[2,1]+C[2,2]*D[2,1]      A[2,1]*B[2,2]+C[2,1]*D[2,2]  A[2,2]*B[2,2]+C[2,2]*D[2,2]]) 
+            # A[2,1]*B[2,1]+C[2,1]*D[2,1]      A[2,2]*B[2,1]+C[2,2]*D[2,1]      A[2,1]*B[2,2]+C[2,1]*D[2,2]  A[2,2]*B[2,2]+C[2,2]*D[2,2]])
             @inbounds  R[1,1] = A[1,1]*B[1,1]+C[1,1]*D[1,1]
             @inbounds  R[1,2] = A[1,2]*B[1,1]+C[1,2]*D[1,1]
             @inbounds  R[1,3] = A[1,1]*B[1,2]+C[1,1]*D[1,2]
@@ -1717,7 +1717,7 @@ end
             @inbounds  R[2,4] = A[2,2]*B[1,2]+C[2,2]*D[1,2]
             @inbounds  R[3,1] = A[1,1]*B[2,1]+C[1,1]*D[2,1]
             @inbounds  R[3,2] = A[1,2]*B[2,1]+C[1,2]*D[2,1]
-            @inbounds  R[3,3] = A[1,1]*B[2,2]+C[1,1]*D[2,2] 
+            @inbounds  R[3,3] = A[1,1]*B[2,2]+C[1,1]*D[2,2]
             @inbounds  R[3,4] = A[1,2]*B[2,2]+C[1,2]*D[2,2]
             @inbounds  R[4,1] = A[2,1]*B[2,1]+C[2,1]*D[2,1]
             @inbounds  R[4,2] = A[2,2]*B[2,1]+C[2,2]*D[2,1]
@@ -1732,7 +1732,7 @@ end
       #R = kron(B,A) + kron(D,C)
    else
       if na == 1
-         # R12 = 
+         # R12 =
          # [ a11*b11 + c11*d11, a11*b12 + c11*d12]
          # [ a11*b21 + c11*d21, a11*b22 + c11*d22]
          # @inbounds R = [ A[1,1]*B[1,1]+C[1,1]*D[1,1]      A[1,1]*B[1,2]+C[1,1]*D[1,2];
@@ -1745,7 +1745,7 @@ end
          # @inbounds  Y[2] = E[1,2]
       else
          if nb == 1
-            # R21 = 
+            # R21 =
             # [ a11*b11 + c11*d11, a21*b11 + c21*d11]
             # [ a12*b11 + c12*d11, a22*b11 + c22*d11]
             # @inbounds R = [ A[1,1]*B[1,1]+C[1,1]*D[1,1]      A[2,1]*B[1,1]+C[2,1]*D[1,1];
@@ -1757,7 +1757,7 @@ end
             # @inbounds  Y[1] = E[1,1]
             # @inbounds  Y[2] = E[2,1]
          else
-            # R = 
+            # R =
             # [ a11*b11 + c11*d11, a21*b11 + c21*d11, a11*b12 + c11*d12, a21*b12 + c21*d12]
             # [ a12*b11 + c12*d11, a22*b11 + c22*d11, a12*b12 + c12*d12, a22*b12 + c22*d12]
             # [ a11*b21 + c11*d21, a21*b21 + c21*d21, a11*b22 + c11*d22, a21*b22 + c21*d22]
@@ -1770,7 +1770,7 @@ end
             # (@inbounds R = [ A[1,1]*B[1,1]+C[1,1]*D[1,1]      A[2,1]*B[1,1]+C[2,1]*D[1,1]      A[1,1]*B[1,2]+C[1,1]*D[1,2]      A[2,1]*B[1,2]+C[2,1]*D[1,2];
             # A[1,2]*B[1,1]+C[1,2]*D[1,1]  A[2,2]*B[1,1]+C[2,2]*D[1,1]      A[1,2]*B[1,2]+C[1,2]*D[1,2]      A[2,2]*B[1,2]+C[2,2]*D[1,2];
             # A[1,1]*B[2,1]+C[1,1]*D[2,1]      A[2,1]*B[2,1]+C[2,1]*D[2,1]  A[1,1]*B[2,2]+C[1,1]*D[2,2]      A[2,1]*B[2,2]+C[2,1]*D[2,2];
-            # A[1,2]*B[2,1]+C[1,2]*D[2,1]      A[2,2]*B[2,1]+C[2,2]*D[2,1]      A[1,2]*B[2,2]+C[1,2]*D[2,2]  A[2,2]*B[2,2]+C[2,2]*D[2,2]]) 
+            # A[1,2]*B[2,1]+C[1,2]*D[2,1]      A[2,2]*B[2,1]+C[2,2]*D[2,1]      A[1,2]*B[2,2]+C[1,2]*D[2,2]  A[2,2]*B[2,2]+C[2,2]*D[2,2]])
             @inbounds  R[1,1] = A[1,1]*B[1,1]+C[1,1]*D[1,1]
             @inbounds  R[1,2] = A[2,1]*B[1,1]+C[2,1]*D[1,1]
             @inbounds  R[1,3] = A[1,1]*B[1,2]+C[1,1]*D[1,2]
@@ -1781,7 +1781,7 @@ end
             @inbounds  R[2,4] = A[2,2]*B[1,2]+C[2,2]*D[1,2]
             @inbounds  R[3,1] = A[1,1]*B[2,1]+C[1,1]*D[2,1]
             @inbounds  R[3,2] = A[2,1]*B[2,1]+C[2,1]*D[2,1]
-            @inbounds  R[3,3] = A[1,1]*B[2,2]+C[1,1]*D[2,2] 
+            @inbounds  R[3,3] = A[1,1]*B[2,2]+C[1,1]*D[2,2]
             @inbounds  R[3,4] = A[2,1]*B[2,2]+C[2,1]*D[2,2]
             @inbounds  R[4,1] = A[1,2]*B[2,1]+C[1,2]*D[2,1]
             @inbounds  R[4,2] = A[2,2]*B[2,1]+C[2,2]*D[2,1]
@@ -2069,7 +2069,7 @@ solution `(X,Y)` is contained in `(C,F)`.
 """
 function dsylvsyss!(A::T1, B::T1, C::T1, D::T1, E::T1, F::T1) where {T<:BlasFloat,T1<:Matrix{T}}
    """
-   This is an interface to the LAPACK.tgsyl! function with `trans = 'T' or `trans = 'C'`. 
+   This is an interface to the LAPACK.tgsyl! function with `trans = 'T' or `trans = 'C'`.
    """
    # MF = -F
    # E, F, scale =  tgsyl!(T <: Complex ? 'C' : 'T', A, B, C, D, E, MF)

--- a/src/sylvkr.jl
+++ b/src/sylvkr.jl
@@ -9,14 +9,14 @@ using the Kronecker product expansion of equations. `A` and `B` are
 square matrices, and `A` and `-B` must not have common eigenvalues.
 This function is not recommended for large order matrices.
 """
-function sylvckr(A,B,C)
-
-   m, n = size(C);
-   [m; n] == LinearAlgebra.checksquare(A,B) || 
+function sylvckr(A, B, C)
+    m, n = size(C)
+    [m; n] == LinearAlgebra.checksquare(A, B) ||
              throw(DimensionMismatch("A, B and Q have incompatible dimensions"))
-   reshape((kron(Array{eltype(A),2}(I,n,n),A)+
-            kron(transpose(B),Array{eltype(B),2}(I,m,m)))\(C[:]),m,n)
+    reshape((kron(Array{eltype(A),2}(I, n, n), A) +
+            kron(transpose(B), Array{eltype(B),2}(I, m, m))) \ (C[:]),m,n)
 end
+
 """
     X = sylvdkr(A,B,C)
 
@@ -28,13 +28,13 @@ using the Kronecker product expansion of equations. `A` and `B` are
 square matrices, and `A` and `-B` must not have common reciprocal eigenvalues.
 This function is not recommended for large order matrices.
 """
-function sylvdkr(A,B,C)
-
-    m, n = size(C);
-    [m; n] == LinearAlgebra.checksquare(A,B) ||
-              throw(DimensionMismatch("A, B and C have incompatible dimensions"))
-     reshape((kron(transpose(B),A)+I)\(C[:]),m,n)
+function sylvdkr(A, B, C)
+    m, n = size(C)
+    [m; n] == LinearAlgebra.checksquare(A, B) ||
+            throw(DimensionMismatch("A, B and C have incompatible dimensions"))
+    reshape((kron(transpose(B), A) + I) \ (C[:]), m, n)
 end
+
 """
     X = gsylvkr(A,B,C,D,E)
 
@@ -47,13 +47,13 @@ square matrices. The pencils `A-λC` and `D+λB` must be regular and
 must not have common eigenvalues.
 This function is not recommended for large order matrices.
 """
-function gsylvkr(A,B,C,D,E)
-
-    m, n = size(E);
-    [m; n; m; n] == LinearAlgebra.checksquare(A,B,C,D) ||
-                    throw(DimensionMismatch("A, B, C, D and E have incompatible dimensions"))
-    reshape((kron(transpose(B),A)+kron(transpose(D),C))\(E[:]),m,n)
+function gsylvkr(A, B, C, D, E)
+   m, n = size(E)
+   [m; n; m; n] == LinearAlgebra.checksquare(A, B, C, D) ||
+                  throw(DimensionMismatch("A, B, C, D and E have incompatible dimensions"))
+   reshape((kron(transpose(B), A) + kron(transpose(D), C)) \ (E[:]), m, n)
 end
+
 """
     sylvsyskr(A,B,C,D,E,F) -> (X,Y)
 
@@ -67,38 +67,37 @@ pairs of square matrices of the same size.
 The pencils `A-λD` and `-B+λE` must be regular and must not have common eigenvalues.
 This function is not recommended for large order matrices.
 """
-function sylvsyskr(A,B,C,D,E,F)
-
-    m, n = size(C);
-    (m == size(F,1) && n == size(F,2)) ||
-          throw(DimensionMismatch("C and F must have the same dimensions"))
-    [m; n; m; n] == LinearAlgebra.checksquare(A,B,D,E) ||
-                    throw(DimensionMismatch("A, B, C, D, E and F have incompatible dimensions"))
-     z = [ kron(Array{eltype(A),2}(I,n,n),A) kron(transpose(B),Array{eltype(B),2}(I,m,m)) ;
-          kron(Array{eltype(D),2}(I,n,n),D) kron(transpose(E),Array{eltype(E),2}(I,m,m))] \ [C[:];F[:]]
-    (reshape(z[1:m*n],m,n),reshape(z[m*n+1:end],m,n))
+function sylvsyskr(A, B, C, D, E, F)
+   m, n = size(C)
+   (m == size(F, 1) && n == size(F, 2)) ||
+         throw(DimensionMismatch("C and F must have the same dimensions"))
+   [m; n; m; n] == LinearAlgebra.checksquare(A, B, D, E) ||
+                  throw(DimensionMismatch("A, B, C, D, E and F have incompatible dimensions"))
+   z = [ kron(Array{eltype(A),2}(I, n, n), A) kron(transpose(B), Array{eltype(B),2}(I, m, m)) ;
+         kron(Array{eltype(D),2}(I, n, n), D) kron(transpose(E), Array{eltype(E),2}(I, m, m))] \ [C[:];F[:]]
+   (reshape(z[1:m * n], m, n), reshape(z[m * n + 1:end], m, n))
 end
+
 """
     dsylvsyskr(A,B,C,D,E,F) -> (X,Y)
 
 Solve the dual Sylvester system of matrix equations
 
        AX + DY = C
-       XB + YE = F 
+       XB + YE = F
 
 using the Kronecker product expansion of equations. `(A,D)`, `(B,E)` are
 pairs of square matrices of the same size.
 The pencils `A-λD` and `-B+λE` must be regular and must not have common eigenvalues.
 This function is not recommended for large order matrices.
 """
-function dsylvsyskr(A,B,C,D,E,F)
-
-    m, n = size(C);
-    (m == size(F,1) && n == size(F,2)) ||
-          throw(DimensionMismatch("C and F must have the same dimensions"))
-    [m; n; m; n] == LinearAlgebra.checksquare(A,B,D,E) ||
-                    throw(DimensionMismatch("A, B, C, D, E and F have incompatible dimensions"))
-    z = [ kron(Array{eltype(A),2}(I,n,n),A) kron(Array{eltype(D),2}(I,n,n),D);
-          kron(transpose(B),Array{eltype(B),2}(I,m,m)) kron(transpose(E),Array{eltype(E),2}(I,m,m))] \ [C[:];F[:]]
-    (reshape(z[1:m*n],m,n),reshape(z[m*n+1:end],m,n))
+function dsylvsyskr(A, B, C, D, E, F)
+   m, n = size(C)
+   (m == size(F, 1) && n == size(F, 2)) ||
+         throw(DimensionMismatch("C and F must have the same dimensions"))
+   [m; n; m; n] == LinearAlgebra.checksquare(A, B, D, E) ||
+                  throw(DimensionMismatch("A, B, C, D, E and F have incompatible dimensions"))
+   z = [ kron(Array{eltype(A),2}(I, n, n), A) kron(Array{eltype(D),2}(I, n, n), D);
+         kron(transpose(B), Array{eltype(B),2}(I, m, m)) kron(transpose(E), Array{eltype(E),2}(I, m, m))] \ [C[:];F[:]]
+   (reshape(z[1:m * n], m, n), reshape(z[m * n + 1:end], m, n))
 end


### PR DESCRIPTION
This is an unsolicited :) review and cleanup of the LinearMap part. One major motivation was to add type parameters for the specific types of matrix fields, in order to have concrete types and make the compiler aware of the types of the struct fields. This follows a recommendation from the Julia performance tipps. Also, I tried to reduce the allocation of intermediate (mostly) vectors. Other changes are more of style nature, e.g., I noticed that the indentation was quite irregular, so I fixed that along the way. Feel free to ask for partial reversions or changes as you prefer.

Do you have some benchmarks to see if there are any improvements or regressions?