### PR TITLE
check zero division

### DIFF
--- a/src/lyapunov.jl
+++ b/src/lyapunov.jl
@@ -474,7 +474,10 @@ function lyapcs!(A::AbstractMatrix{T1},C::AbstractMatrix{T1}; adj = false) where
       throw(DimensionMismatch("C must be a $n x $n symmetric matrix"))
    if isdiag(A) 
       for i = 1:n
-         C[i,i] = -C[i,i]/(2*A[i,i])
+         if A[i,i] != 0 || C[i,i] != 0
+             C[i,i] = -C[i,i]/(2*A[i,i])
+         end
+         isfinite(C[i,i]) || throw("ME:SingularException: A has eigenvalue(s) == 0")
          for j = i+1:n
             C[i,j] = -C[i,j]/(A[i,i]+A[j,j])
             isfinite(C[i,j]) || throw("ME:SingularException: A has eigenvalue(s) α and β such that α+β = 0")

--- a/test/test_clyap.jl
+++ b/test/test_clyap.jl
@@ -68,6 +68,10 @@ catch
   @test true
 end  
 
+#innocent singularity
+x = lyapc([2 1 0; 1 2 0; 0 0 0], zeros(3,3))
+@test x == zeros(3,3)
+
 for Ty in (Float64, Float32, BigFloat, Double64)
 
 ar = rand(Ty,n,n); ars = Symmetric(ar);


### PR DESCRIPTION
I had a problem solving a Lyapunov equation, which I tracked down to an unchecked by zero in `lyapcs!`. I fixed that, while simultaneously allowing the harmless case 0/0 to go through (which I needed for my problem).

To reproduce, try `lyapc([2 1 0; 1 2 0; 0 0 0], zeros(3,3))`. I gives the rather unhelpful error "Q must be a symmetric/hermitian matrix".